### PR TITLE
[Feat/#9] SpeechToText Authorization Handling

### DIFF
--- a/talklat/talklat.xcodeproj/project.pbxproj
+++ b/talklat/talklat.xcodeproj/project.pbxproj
@@ -14,6 +14,10 @@
 		7E8D17D62ACE8AED00E904E5 /* talklatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17D52ACE8AED00E904E5 /* talklatTests.swift */; };
 		7E8D17E02ACE8AED00E904E5 /* talklatUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17DF2ACE8AED00E904E5 /* talklatUITests.swift */; };
 		7E8D17E22ACE8AED00E904E5 /* talklatUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17E12ACE8AED00E904E5 /* talklatUITestsLaunchTests.swift */; };
+		EF67C64B2ACEB67000C1074E /* SpeechRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF67C64A2ACEB67000C1074E /* SpeechRecognizer.swift */; };
+		EF67C64D2ACEB69500C1074E /* HandlingTestingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF67C64C2ACEB69500C1074E /* HandlingTestingView.swift */; };
+		EF67C6532AD13BF700C1074E /* AppRootManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF67C6522AD13BF700C1074E /* AppRootManager.swift */; };
+		EF67C6572AD1414300C1074E /* AuthorizationRequestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF67C6562AD1414300C1074E /* AuthorizationRequestView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -44,6 +48,10 @@
 		7E8D17DB2ACE8AED00E904E5 /* talklatUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = talklatUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E8D17DF2ACE8AED00E904E5 /* talklatUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = talklatUITests.swift; sourceTree = "<group>"; };
 		7E8D17E12ACE8AED00E904E5 /* talklatUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = talklatUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		EF67C64A2ACEB67000C1074E /* SpeechRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognizer.swift; sourceTree = "<group>"; };
+		EF67C64C2ACEB69500C1074E /* HandlingTestingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandlingTestingView.swift; sourceTree = "<group>"; };
+		EF67C6522AD13BF700C1074E /* AppRootManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRootManager.swift; sourceTree = "<group>"; };
+		EF67C6562AD1414300C1074E /* AuthorizationRequestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationRequestView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,6 +146,7 @@
 		7E8D17EF2ACE8B8900E904E5 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				EF67C6492ACEB65400C1074E /* Managers */,
 				7E8D17F02ACE8BA300E904E5 /* Views */,
 			);
 			path = Sources;
@@ -146,9 +155,20 @@
 		7E8D17F02ACE8BA300E904E5 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				EF67C64C2ACEB69500C1074E /* HandlingTestingView.swift */,
+				EF67C6562AD1414300C1074E /* AuthorizationRequestView.swift */,
 				7E8D17C62ACE8AEC00E904E5 /* ContentView.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		EF67C6492ACEB65400C1074E /* Managers */ = {
+			isa = PBXGroup;
+			children = (
+				EF67C64A2ACEB67000C1074E /* SpeechRecognizer.swift */,
+				EF67C6522AD13BF700C1074E /* AppRootManager.swift */,
+			);
+			path = Managers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -282,7 +302,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				7E8D17C72ACE8AEC00E904E5 /* ContentView.swift in Sources */,
+				EF67C6532AD13BF700C1074E /* AppRootManager.swift in Sources */,
 				7E8D17C52ACE8AEC00E904E5 /* talklatApp.swift in Sources */,
+				EF67C64D2ACEB69500C1074E /* HandlingTestingView.swift in Sources */,
+				EF67C64B2ACEB67000C1074E /* SpeechRecognizer.swift in Sources */,
+				EF67C6572AD1414300C1074E /* AuthorizationRequestView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -441,9 +465,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"talklat/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = 67M6ZS7KS6;
+				DEVELOPMENT_TEAM = 34U36L8239;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "마이크 좀 쓸게용!";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "음성인식 좀 할게용!";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -470,9 +496,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"talklat/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = 67M6ZS7KS6;
+				DEVELOPMENT_TEAM = 34U36L8239;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "마이크 좀 쓸게용!";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "음성인식 좀 할게용!";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/talklat/talklat/Sources/Managers/AppRootManager.swift
+++ b/talklat/talklat/Sources/Managers/AppRootManager.swift
@@ -1,0 +1,57 @@
+//
+//  AppRootManager.swift
+//  talklat
+//
+//  Created by Ye Eun Choi on 2023/10/07.
+//
+
+import Foundation
+import Speech
+
+public class AppRootManager: ObservableObject {
+    @Published var currentRoot: StartMode = .authCompleted
+
+    public enum StartMode: String {
+        case authCompleted
+        case speechRecognitionAuthIncompleted = "음성 인식"
+        case microphoneAuthIncompleted = "마이크"
+        case authIncompleted = "마이크, 음성"
+    }
+}
+
+// MARK: - Switch Authorization Status
+/// 시스템 마이크, 음성인식 권한 허용에 맞게 뷰를 반영합니다.
+@MainActor
+extension AppRootManager {
+    public func switchAuthorizationStatus() async {
+        var isSpeechRecognitionAuthorized: Bool = true
+        var isMicrophoneAuthorized: Bool = true
+        
+        if await SFSpeechRecognizer.hasAuthorizationToRecognize() == true {
+            isSpeechRecognitionAuthorized = true
+            print("음성 인식 허용 됨!")
+            
+        } else {
+            isSpeechRecognitionAuthorized = false
+            print("음성 인식 허용 안됨ㅠ")
+        }
+        
+        if await AVAudioSession.sharedInstance().hasPermissionToRecord() == true {
+            isMicrophoneAuthorized = true
+            print("마이크 허용 됨!")
+        } else {
+            isMicrophoneAuthorized = false
+            print("마이크 허용 안됨ㅠ")
+        }
+        
+        if isSpeechRecognitionAuthorized && isMicrophoneAuthorized == true {
+            currentRoot = .authCompleted
+        } else if isSpeechRecognitionAuthorized == false && isMicrophoneAuthorized == true {
+            currentRoot = .speechRecognitionAuthIncompleted
+        } else if isSpeechRecognitionAuthorized == true && isMicrophoneAuthorized == false {
+            currentRoot = .microphoneAuthIncompleted
+        } else {
+            currentRoot = .authIncompleted
+        }
+    }
+}

--- a/talklat/talklat/Sources/Managers/AppRootManager.swift
+++ b/talklat/talklat/Sources/Managers/AppRootManager.swift
@@ -16,7 +16,7 @@ public class AppRootManager: ObservableObject {
         case authIncompleted = "마이크, 음성"
     }
     
-    @Published var currentRoot: AuthStatus = .authCompleted
+    @Published var currentAuthStatus: AuthStatus = .authCompleted
     
     var isSpeechRecognitionAuthorized: Bool = true
     var isMicrophoneAuthorized: Bool = true
@@ -30,13 +30,13 @@ extension AppRootManager {
         await getAuthStatus()
         
         if isSpeechRecognitionAuthorized && isMicrophoneAuthorized == true {
-            currentRoot = .authCompleted
+            currentAuthStatus = .authCompleted
         } else if isSpeechRecognitionAuthorized == false && isMicrophoneAuthorized == true {
-            currentRoot = .speechRecognitionAuthIncompleted
+            currentAuthStatus = .speechRecognitionAuthIncompleted
         } else if isSpeechRecognitionAuthorized == true && isMicrophoneAuthorized == false {
-            currentRoot = .microphoneAuthIncompleted
+            currentAuthStatus = .microphoneAuthIncompleted
         } else {
-            currentRoot = .authIncompleted
+            currentAuthStatus = .authIncompleted
         }
     }
     

--- a/talklat/talklat/Sources/Managers/AppRootManager.swift
+++ b/talklat/talklat/Sources/Managers/AppRootManager.swift
@@ -9,40 +9,25 @@ import Foundation
 import Speech
 
 public class AppRootManager: ObservableObject {
-    @Published var currentRoot: StartMode = .authCompleted
-
-    public enum StartMode: String {
+    public enum AuthStatus: String {
         case authCompleted
         case speechRecognitionAuthIncompleted = "음성 인식"
         case microphoneAuthIncompleted = "마이크"
         case authIncompleted = "마이크, 음성"
     }
+    
+    @Published var currentRoot: AuthStatus = .authCompleted
+    
+    var isSpeechRecognitionAuthorized: Bool = true
+    var isMicrophoneAuthorized: Bool = true
 }
 
 // MARK: - Switch Authorization Status
 /// 시스템 마이크, 음성인식 권한 허용에 맞게 뷰를 반영합니다.
 @MainActor
 extension AppRootManager {
-    public func switchAuthorizationStatus() async {
-        var isSpeechRecognitionAuthorized: Bool = true
-        var isMicrophoneAuthorized: Bool = true
-        
-        if await SFSpeechRecognizer.hasAuthorizationToRecognize() == true {
-            isSpeechRecognitionAuthorized = true
-            print("음성 인식 허용 됨!")
-            
-        } else {
-            isSpeechRecognitionAuthorized = false
-            print("음성 인식 허용 안됨ㅠ")
-        }
-        
-        if await AVAudioSession.sharedInstance().hasPermissionToRecord() == true {
-            isMicrophoneAuthorized = true
-            print("마이크 허용 됨!")
-        } else {
-            isMicrophoneAuthorized = false
-            print("마이크 허용 안됨ㅠ")
-        }
+    public func switchAuthStatus() async {
+        await getAuthStatus()
         
         if isSpeechRecognitionAuthorized && isMicrophoneAuthorized == true {
             currentRoot = .authCompleted
@@ -52,6 +37,20 @@ extension AppRootManager {
             currentRoot = .microphoneAuthIncompleted
         } else {
             currentRoot = .authIncompleted
+        }
+    }
+    
+    private func getAuthStatus() async {
+        if await SFSpeechRecognizer.hasAuthorizationToRecognize() == true {
+            isSpeechRecognitionAuthorized = true
+        } else {
+            isSpeechRecognitionAuthorized = false
+        }
+        
+        if await AVAudioSession.sharedInstance().hasPermissionToRecord() == true {
+            isMicrophoneAuthorized = true
+        } else {
+            isMicrophoneAuthorized = false
         }
     }
 }

--- a/talklat/talklat/Sources/Managers/SpeechRecognizer.swift
+++ b/talklat/talklat/Sources/Managers/SpeechRecognizer.swift
@@ -1,0 +1,183 @@
+//
+//  SpeechRecognizer.swift
+//  talklat
+//
+//  Created by Ye Eun Choi on 2023/10/05.
+//
+
+import AVFoundation
+import Foundation
+import Speech
+import SwiftUI
+
+/// A helper for transcribing speech to text using SFSpeechRecognizer and AVAudioEngine.
+class SpeechRecognizer: ObservableObject {
+    enum RecognizerError: Error {
+        case nilRecognizer
+        case notAuthorizedToRecognize
+        case notPermittedToRecord
+        case recognizerIsUnavailable
+        
+        var message: String {
+            switch self {
+            case .nilRecognizer: return "Can't initialize speech recognizer"
+            case .notAuthorizedToRecognize: return "Not authorized to recognize speech"
+            case .notPermittedToRecord: return "Not permitted to record audio"
+            case .recognizerIsUnavailable: return "Recognizer is unavailable"
+            }
+        }
+    }
+    
+    @Published var transcript: String = ""
+    
+    private var audioEngine: AVAudioEngine?
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+    private let recognizer: SFSpeechRecognizer?
+    
+    /**
+     Initializes a new speech recognizer. If this is the first time you've used the class, it
+     requests access to the speech recognizer and the microphone.
+     */
+    init() {
+        recognizer = SFSpeechRecognizer(locale: Locale(identifier: "ko_KR"))
+    
+        guard recognizer != nil else {
+            transcribe(RecognizerError.nilRecognizer)
+            return
+        }
+        
+        Task {
+            do {
+                guard await SFSpeechRecognizer.hasAuthorizationToRecognize() else {
+                    throw RecognizerError.notAuthorizedToRecognize
+                }
+                guard await AVAudioSession.sharedInstance().hasPermissionToRecord() else {
+                    throw RecognizerError.notPermittedToRecord
+                }
+            } catch {
+                transcribe(error)
+            }
+        }
+    }
+    
+    @MainActor func startTranscribing() {
+        Task {
+            await transcribe()
+        }
+    }
+    
+    @MainActor func stopTranscribing() {
+        Task {
+            await reset()
+        }
+    }
+    
+    /**
+     Begin transcribing audio.
+     Creates a `SFSpeechRecognitionTask` that transcribes speech to text until you call `stopTranscribing()`.
+     The resulting transcription is continuously written to the published `transcript` property.
+     */
+    func transcribe() {
+        guard let recognizer, recognizer.isAvailable else {
+            self.transcribe(RecognizerError.recognizerIsUnavailable)
+            return
+        }
+        
+        do {
+            let (audioEngine, request) = try Self.prepareEngine()
+            self.audioEngine = audioEngine
+            self.request = request
+            self.task = recognizer.recognitionTask(with: request, resultHandler: { [weak self] result, error in
+                self?.recognitionHandler(audioEngine: audioEngine, result: result, error: error)
+            })
+        
+        } catch {
+            self.reset()
+            self.transcribe(error)
+        }
+    }
+    
+    /// Reset the speech recognizer.
+    private func reset() {
+        task?.cancel()
+        audioEngine?.stop()
+        audioEngine = nil
+        request = nil
+        task = nil
+    }
+    
+    private static func prepareEngine() throws -> (AVAudioEngine, SFSpeechAudioBufferRecognitionRequest) {
+        let audioEngine = AVAudioEngine()
+        
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.playAndRecord, mode: .measurement, options: .duckOthers)
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+        let inputNode = audioEngine.inputNode
+        
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { (buffer: AVAudioPCMBuffer, when: AVAudioTime) in
+            request.append(buffer)
+        }
+        audioEngine.prepare()
+        try audioEngine.start()
+        
+        return (audioEngine, request)
+    }
+    
+    private func recognitionHandler(audioEngine: AVAudioEngine, result: SFSpeechRecognitionResult?, error: Error?) {
+        let receivedFinalResult = result?.isFinal ?? false
+        let receivedError = error != nil
+        
+        if receivedFinalResult || receivedError {
+            audioEngine.stop()
+            audioEngine.inputNode.removeTap(onBus: 0)
+        }
+        
+        if let result {
+            transcribe(result.bestTranscription.formattedString)
+        }
+    }
+    
+    private func transcribe(_ message: String) {
+        Task { @MainActor in
+            transcript = message
+        }
+    }
+    
+    private func transcribe(_ error: Error) {
+        var errorMessage = ""
+        if let error = error as? RecognizerError {
+            errorMessage += error.message
+        } else {
+            errorMessage += error.localizedDescription
+        }
+        Task { @MainActor [errorMessage] in
+            transcript = "<< \(errorMessage) >>"
+        }
+    }
+}
+
+// MARK: - 여기서 권한 요청 메서드 이름만 일치하면 다른 코드는 대체 가능!
+extension SFSpeechRecognizer {
+    static func hasAuthorizationToRecognize() async -> Bool {
+        await withCheckedContinuation { continuation in
+            requestAuthorization { status in
+                continuation.resume(returning: status == .authorized)
+            }
+        }
+    }
+}
+
+extension AVAudioSession {
+    func hasPermissionToRecord() async -> Bool {
+        await withCheckedContinuation { continuation in
+            requestRecordPermission { authorized in
+                continuation.resume(returning: authorized)
+            }
+        }
+    }
+}

--- a/talklat/talklat/Sources/Views/AuthorizationRequestView.swift
+++ b/talklat/talklat/Sources/Views/AuthorizationRequestView.swift
@@ -8,12 +8,12 @@
 import SwiftUI
 
 struct AuthorizationRequestView: View {
-    var currentRoot: AppRootManager.AuthStatus
+    var currentAuthStatus: AppRootManager.AuthStatus
     
     var body: some View {
         VStack(spacing: 30) {
             /// 권한 사용 안내 문구
-            Text("현재 **\(currentRoot.rawValue)** 권한이 꺼져있어요.")
+            Text("현재 **\(currentAuthStatus.rawValue)** 권한이 꺼져있어요.")
             Text("마이크와 음성 인식 기능은\n인식된 음성을 텍스트로 변환하기 위해 쓰이고 있어요.\n앱 사용을 희망하신다면 권한 허용 부탁드릴게요!🙏")
                 .font(.footnote)
                 .multilineTextAlignment(.center)
@@ -36,6 +36,6 @@ struct AuthorizationRequestView: View {
 
 struct AuthorizationSettingView_Previews: PreviewProvider {
     static var previews: some View {
-        AuthorizationRequestView(currentRoot: .authIncompleted)
+        AuthorizationRequestView(currentAuthStatus: .authIncompleted)
     }
 }

--- a/talklat/talklat/Sources/Views/AuthorizationRequestView.swift
+++ b/talklat/talklat/Sources/Views/AuthorizationRequestView.swift
@@ -1,0 +1,41 @@
+//
+//  AuthorizationRequestView.swift
+//  talklat
+//
+//  Created by Ye Eun Choi on 2023/10/07.
+//
+
+import SwiftUI
+
+struct AuthorizationRequestView: View {
+    var currentRoot: AppRootManager.StartMode
+    
+    var body: some View {
+        VStack(spacing: 30) {
+            /// 권한 사용 안내 문구
+            Text("현재 **\(currentRoot.rawValue)** 권한이 꺼져있어요.")
+            Text("마이크와 음성 인식 기능은\n인식된 음성을 텍스트로 변환하기 위해 쓰이고 있어요.\n앱 사용을 희망하신다면 권한 허용 부탁드릴게요!🙏")
+                .font(.footnote)
+                .multilineTextAlignment(.center)
+                .foregroundColor(.gray)
+            
+            
+            Button("불쌍하니까 권한 주러 가기") {
+                /// 권한 허용을 위한 앱 시스템설정으로 이동
+                if let url = URL(
+                    string: UIApplication.openSettingsURLString
+                ) {
+                    UIApplication.shared.open(url)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+}
+
+
+struct AuthorizationSettingView_Previews: PreviewProvider {
+    static var previews: some View {
+        AuthorizationRequestView(currentRoot: .authIncompleted)
+    }
+}

--- a/talklat/talklat/Sources/Views/AuthorizationRequestView.swift
+++ b/talklat/talklat/Sources/Views/AuthorizationRequestView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct AuthorizationRequestView: View {
-    var currentRoot: AppRootManager.StartMode
+    var currentRoot: AppRootManager.AuthStatus
     
     var body: some View {
         VStack(spacing: 30) {

--- a/talklat/talklat/Sources/Views/HandlingTestingView.swift
+++ b/talklat/talklat/Sources/Views/HandlingTestingView.swift
@@ -1,0 +1,59 @@
+//
+//  HandlingTestingView.swift
+//  talklat
+//
+//  Created by Ye Eun Choi on 2023/10/05.
+//
+
+import SwiftUI
+
+struct HandlingTestingView: View {
+    @EnvironmentObject private var appRootManager: AppRootManager
+    @ObservedObject var speechRecognizer = SpeechRecognizer()
+    @State private var isRecording = false
+    
+    var body: some View {
+        VStack(spacing: 50) {
+            HStack(alignment: .top, spacing: 20) {
+                Button("음성인식 시작") {
+                    startScrum()
+                    print("convertedText: ", speechRecognizer.transcript)
+                }
+                .buttonStyle(.borderedProminent)
+                .fontWeight(.semibold)
+                
+                Button("음성인식 종료") {
+                    endScrum()
+                }
+                .buttonStyle(.borderedProminent)
+                .fontWeight(.semibold)
+                .tint(.red)
+            }
+            .padding(.top, 40)
+            
+            /// 인식 내용
+            Text(speechRecognizer.transcript)
+                .font(.largeTitle)
+            
+            Spacer()
+        }
+        .frame(maxHeight: .infinity)
+        .padding(.horizontal, 20)
+    }
+    
+    private func startScrum() {
+        speechRecognizer.startTranscribing()
+        isRecording = true
+    }
+    
+    private func endScrum() {
+        speechRecognizer.stopTranscribing()
+        isRecording = false
+    }
+}
+
+struct HandlingTestingView_Previews: PreviewProvider {
+    static var previews: some View {
+        HandlingTestingView()
+    }
+}

--- a/talklat/talklat/talklatApp.swift
+++ b/talklat/talklat/talklatApp.swift
@@ -14,14 +14,14 @@ struct talklatApp: App {
     var body: some Scene {
         WindowGroup {
             Group {
-                switch appRootManager.currentRoot {
+                switch appRootManager.currentAuthStatus {
                 case .authCompleted:
                     HandlingTestingView()
                 case .speechRecognitionAuthIncompleted,
                         .microphoneAuthIncompleted,
                         .authIncompleted:
                     AuthorizationRequestView(
-                        currentRoot: appRootManager.currentRoot
+                        currentAuthStatus: appRootManager.currentAuthStatus
                     )
                 }
             }

--- a/talklat/talklat/talklatApp.swift
+++ b/talklat/talklat/talklatApp.swift
@@ -27,7 +27,7 @@ struct talklatApp: App {
             }
             .environmentObject(appRootManager)
             .task {
-                await appRootManager.switchAuthorizationStatus()
+                await appRootManager.switchAuthStatus()
             }
         }
     }

--- a/talklat/talklat/talklatApp.swift
+++ b/talklat/talklat/talklatApp.swift
@@ -9,9 +9,26 @@ import SwiftUI
 
 @main
 struct talklatApp: App {
+    @StateObject private var appRootManager = AppRootManager()
+    
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            Group {
+                switch appRootManager.currentRoot {
+                case .authCompleted:
+                    HandlingTestingView()
+                case .speechRecognitionAuthIncompleted,
+                        .microphoneAuthIncompleted,
+                        .authIncompleted:
+                    AuthorizationRequestView(
+                        currentRoot: appRootManager.currentRoot
+                    )
+                }
+            }
+            .environmentObject(appRootManager)
+            .task {
+                await appRootManager.switchAuthorizationStatus()
+            }
         }
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->
<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `SpeechToText Authorization Handling` | 
| :--- | :--- |
| 📜 **Description** | `STT와 관련된 마이크 및 음성인식 권한 허용 분기처리를 진행했습니다.` |
| 📌 **Issue Number** | `#9` |
| ![](https://img.shields.io/badge/-black?logo=figma) **Figma** | [Link](https://www.figma.com/file/Mb450yYTvio6Q9y6d0otwv/%F0%9F%8D%8EALLWAY-Team?type=design&node-id=555%3A2025&mode=design&t=om36ZAhqHVFjsaVJ-1) |
| ![](https://img.shields.io/badge/-black?logo=notion) **Notion Card** | https://www.notion.so/yenchoichoi/Voice-STT-befcc53aa4444336b6626af86adcc3da?pvs=4 |


---

## 작업 사항
<!-- 1. MainIntroView의 ScrollView 구현 -->
1. 마이크, 음성 인식 권한 허용 여부에 따른 화면 분기처리 구현
  -  권한이 허용/비허용 되었을 때의 케이스를 Enum으로 분리하고 처리했습니다.
  - 권한이 비허용 됐을 경우를 위한 임시 뷰를 마련하고 연결했습니다.

### `Logics`
- 권한을 음성 인식, 마이크 두 가지를 받아와야 돼서 분기 케이스를 네 가지로 나눴는데, 사실 둘 중 하나만 안되도 우리 앱을 쓸 수 없기 때문에 뭉뚱그려서 권한 허용/비허용으로 나눠도 됩니다. 다만 현재 어떤 권한이 비활성화 됐는지까지 사용자에게 안내해주는 UX를 고려해 지금처럼 모든 케이스로 구현해둔 상태입니다. 
- 비허용일 때 도달하는 화면들은 lofi에 없는 제가 만든 임시 뷰들이고, 추후에 디자이너 분들이 만들어주시는 형태에 따라 뷰로 받아올 변수가 추가될 수도 생략될 수도 있을 것 같습니다.

```swift 
/**
처리할 경우의 수:
1. 음성인식 허용 + 마이크 허용 --> 원래 뷰
2. 음성인식 허용 + 마이크 비허용 --> "허용 해주세요" 뷰 + 시스템설정 이동 버튼 + "(마이크) 권한 주세요!" 멘트
3. 음성인식 비허용 + 마이크 비허용 --> "허용 해주세요" 뷰 + 시스템설정 이동 버튼 + "(마이크/음성인식) 권한 주세요!" 멘트
4. 음성인식 비허용 + 마이크 허용 --> "허용 해주세요" 뷰 + 시스템설정 이동 버튼 + "(음성인식) 권한 주세요!" 멘트
*/
    
 public enum StartMode: String {
    case authCompleted
    case speechRecognitionAuthIncompleted = "음성 인식"
    case microphoneAuthIncompleted = "마이크"
    case authIncompleted = "마이크, 음성"
}
```

---

## 작업 결과
<img width="1190" alt="Screenshot 2023-10-07 at 5 25 24 PM" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/89244357/b5ef8410-8887-4500-b561-3adae00a91f0">

---

#### 기타 공유사항
- HandlingTestingView, SpeechRecognizer 모두 임의로 추가된 파일이고 각각 첼란, 매들린의 작업물로 대체될 예정입니다. 
- Speech Recognition 관련 매니저에서 권한을 요청하는 메서드들(hasAuthorizationToRecognize, hasPermissionToRecord)의 이름만 동일하다면 오류는 나지 않습니다. 
