### PR TITLE
[Feat/#7] CoreMotion 으로 flip 상태 표시 구현

### DIFF
--- a/talklat/talklat.xcodeproj/project.pbxproj
+++ b/talklat/talklat.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		7E8D17D62ACE8AED00E904E5 /* talklatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17D52ACE8AED00E904E5 /* talklatTests.swift */; };
 		7E8D17E02ACE8AED00E904E5 /* talklatUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17DF2ACE8AED00E904E5 /* talklatUITests.swift */; };
 		7E8D17E22ACE8AED00E904E5 /* talklatUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17E12ACE8AED00E904E5 /* talklatUITestsLaunchTests.swift */; };
+		CE9BC85D2ACE8F330062B7E6 /* GyroScopeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9BC85C2ACE8F330062B7E6 /* GyroScopeStore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -44,6 +45,7 @@
 		7E8D17DB2ACE8AED00E904E5 /* talklatUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = talklatUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E8D17DF2ACE8AED00E904E5 /* talklatUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = talklatUITests.swift; sourceTree = "<group>"; };
 		7E8D17E12ACE8AED00E904E5 /* talklatUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = talklatUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		CE9BC85C2ACE8F330062B7E6 /* GyroScopeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GyroScopeStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,6 +140,7 @@
 		7E8D17EF2ACE8B8900E904E5 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				CE9BC85B2ACE8F210062B7E6 /* Stores */,
 				7E8D17F02ACE8BA300E904E5 /* Views */,
 			);
 			path = Sources;
@@ -149,6 +152,14 @@
 				7E8D17C62ACE8AEC00E904E5 /* ContentView.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		CE9BC85B2ACE8F210062B7E6 /* Stores */ = {
+			isa = PBXGroup;
+			children = (
+				CE9BC85C2ACE8F330062B7E6 /* GyroScopeStore.swift */,
+			);
+			path = Stores;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -283,6 +294,7 @@
 			files = (
 				7E8D17C72ACE8AEC00E904E5 /* ContentView.swift in Sources */,
 				7E8D17C52ACE8AEC00E904E5 /* talklatApp.swift in Sources */,
+				CE9BC85D2ACE8F330062B7E6 /* GyroScopeStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -441,7 +453,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"talklat/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = 67M6ZS7KS6;
+				DEVELOPMENT_TEAM = CZH2CMCGCZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -470,7 +482,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"talklat/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = 67M6ZS7KS6;
+				DEVELOPMENT_TEAM = CZH2CMCGCZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/talklat/talklat/Sources/Stores/GyroScopeStore.swift
+++ b/talklat/talklat/Sources/Stores/GyroScopeStore.swift
@@ -1,0 +1,73 @@
+//
+//  GyroScopeManager.swift
+//  talklat
+//
+//  Created by user on 2023/10/05.
+//
+
+import CoreMotion
+import Foundation
+
+enum FlippedStatus: String {
+    case opponent
+    case myself
+}
+
+class GyroScopeStore: ObservableObject {
+    
+    @Published var faced: FlippedStatus = .myself
+    @Published var yaw: Double = 0.0
+    
+    let motionManager: CMMotionManager
+    let timeInterval: Double
+    
+    init() {
+        motionManager = CMMotionManager()
+        timeInterval = 1.0 / 60.0
+    }
+    
+    // Mark: Motion을 감지할때 사용하는 메서드
+    func startDeviceMotion() {
+        if motionManager.isDeviceMotionAvailable {
+            self.motionManager.deviceMotionUpdateInterval = timeInterval
+            self.motionManager.showsDeviceMovementDisplay = true
+            self.motionManager.startDeviceMotionUpdates(
+                using: .xArbitraryCorrectedZVertical,
+                to: .main
+            ) { (data, error) in
+                if let validData = data {
+                    // 실제 coreMotion의 3가지 attitude 중 yaw로 flip 이벤트 측정
+                    let yaw = abs(validData.attitude.yaw.toDegrees())
+                    self.yaw = yaw
+                    
+                    self.faced = {
+                        switch yaw {
+                        case ...90:
+                            return FlippedStatus.myself
+                        case 91...:
+                            return FlippedStatus.opponent
+                        default:
+                            return FlippedStatus.myself
+                        }
+                    }()
+                }
+            }
+        } else {
+            // device에서 core motion을 지원 안할때
+            // 근데 iOS 4.0 이상 전부 지원하니까 괜찮지 않을까 하는 생각
+            fatalError("기기가 CoreMotion을 지원 안함")
+            
+        }
+    }
+    
+    // Mark: MotionManger를 멈출때 쓰는 메서드
+    func stopMotionManager() {
+        self.motionManager.stopDeviceMotionUpdates()
+    }
+}
+
+extension Double {
+    func toDegrees() -> Double {
+        return 180 / Double.pi * self
+    }
+}


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->
<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `GyroScope Flip feature` | 
| :--- | :--- |
| 📜 **Description** | `Flip 이벤트 관련 GyroScopeStore를 만들었습니다.`|
| 📌 **Issue Number** | `#7` |
| ![](https://img.shields.io/badge/-black?logo=figma) **Figma** | `[Link](https://www.figma.com/file/Mb450yYTvio6Q9y6d0otwv/%F0%9F%8D%8EALLWAY-Team?type=design&node-id=555%3A2025&mode=design&t=om36ZAhqHVFjsaVJ-1)` |
| ![](https://img.shields.io/badge/-black?logo=notion) **Notion Card** | `[Link](https://www.notion.so/yenchoichoi/GyroScopeManager-3c656d859728444085bdc125b9d0e763)` |

---

## 작업 사항
<!-- 1. MainIntroView의 ScrollView 구현 -->
1. 작업 내용
  - GyroScope를 이용하기 위해 CoreMotionManager 생성
  - GyroScope의 Attitude 중 1가지를 이용해서 화면이 누구를 향하고 있는지를 구현

### `Logics`
![rpy](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/22471820/831e0aa1-c802-4e98-8093-35727b57eb0d)
x축 회전: Pitch
y축 회전: Roll
z축 회전: Yaw


- GyroScopeStore 클래스를 init 할때 자동적으로 CoreMotionManager가 init되게 해놨습니다. 애플 공식문서에서는 CoreMotionManager가 앱에서 1개만 존재해야한다고 했기때문에, GyroScopeStore를 사용하기 위해서는 추후 싱글톤 형식으로 만들던지 아니면 EnvironmentObject로 만들어서 앱 최상위 파일에 위치시켜야할 것 같습니다.
- 디자인팀에 UX적인 자문을 구하고 여러번의 실험결과 roll, pitch, yaw 총 3가지 attitude 중에서 yaw기준의 회전이 가장 적합하다고 판단해서 yaw를 기준으로 화면의 상태를 파악할 수 있게 하였습니다. 추후에 조금 더 정확한 방법을 도입하도록 하겠습니다.
- 현재는 화면을 y축 기준 절반을 돌렸을때 상태 변화가 일어나도록 하고 있습니다. 이 부분은 UT 이후에 변경이 일어날 수 있을것 같습니다.
- 현재는 1/60초에 한번씩 화면이 사용자를 향하는지 상대방을 향하는지 체크합니다. 이 시간간격은 늘릴수도 줄일수도 있습니다. 



```swift
enum FlippedStatus: String {
    case opponent
    case myself
}

self.faced = {
    switch yaw {
    case ...90:
        return FlippedStatus.myself
    case 91...:
        return FlippedStatus.opponent
    default:
        return FlippedStatus.myself
        }
    }()
```

---

## 작업 결과
<!-- 이미지, gif 등을 캡쳐하여 첨부합니다. -->
<!-- 해당 섹션은 필수가 아닙니다! -->
![GyroScopeStore](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/22471820/2ae8320c-e3ca-42f2-998c-4ebb4df9ffc3)

---

#### 기타 공유사항
- 1초에 60번씩 상태를 체크하기 때문에 조금은 문제가 될 수 있다고 생각합니다. 추후에 combine을 통해서 화면의 변경이 일어났을때만 현재 화면이 누구를 향하는지와 이전 상태에서 변경이 일어났는지를 알려주는 방식은 어떨까? 하고 생각중입니다.
- 우리의 view 안에 .onAppear()로 GyroScopeManager의 startDeviceMotion 메서드를 넣어놓으면, 앱이 백그라운드로 돌아갔을때는 device motion 확인이 멈췄다가, 다시 포그라운드로 돌아오면 작동을 시작합니다.