### PR TITLE
#feat/24 advanced gyro feature

### DIFF
--- a/talklat/talklat.xcodeproj/project.pbxproj
+++ b/talklat/talklat.xcodeproj/project.pbxproj
@@ -527,7 +527,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"talklat/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = 67M6ZS7KS6;
+				DEVELOPMENT_TEAM = CZH2CMCGCZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_LSApplicationCategoryType = "Privacy - Speech Recognition Usage Description";

--- a/talklat/talklat/Sources/Stores/GyroScopeStore.swift
+++ b/talklat/talklat/Sources/Stores/GyroScopeStore.swift
@@ -7,6 +7,7 @@
 
 import CoreMotion
 import Foundation
+import SwiftUI
 
 enum FlippedStatus: String {
     case opponent
@@ -16,40 +17,44 @@ enum FlippedStatus: String {
 class GyroScopeStore: ObservableObject {
     
     @Published var faced: FlippedStatus = .myself
-    @Published var yaw: Double = 0.0
+    private var rotationDegree: Double = 0.0
     
     let motionManager: CMMotionManager
     let timeInterval: Double
+    let queue: OperationQueue = OperationQueue()
     
     init() {
         motionManager = CMMotionManager()
         timeInterval = 1.0 / 60.0
     }
     
-    // Mark: Motion을 감지할때 사용하는 메서드
+    // MARK: Motion을 감지할때 사용하는 메서드
+    // 다른 queue에서 motion을 감지합니다.
     func startDeviceMotion() {
         if motionManager.isDeviceMotionAvailable {
             self.motionManager.deviceMotionUpdateInterval = timeInterval
             self.motionManager.showsDeviceMovementDisplay = true
             self.motionManager.startDeviceMotionUpdates(
                 using: .xArbitraryCorrectedZVertical,
-                to: .main
+                to: queue
             ) { (data, error) in
                 if let validData = data {
-                    // 실제 coreMotion의 3가지 attitude 중 yaw로 flip 이벤트 측정
-                    let yaw = abs(validData.attitude.yaw.toDegrees())
-                    self.yaw = yaw
+                    // MARK: roll, pitch, yaw를 전부 사용해서 attitude를 판단
+                    self.rotationDegree = abs(validData.attitude.pitch.toDegrees()) + abs(validData.attitude.roll.toDegrees()) + abs(validData.attitude.yaw.toDegrees())
                     
-                    self.faced = {
-                        switch yaw {
-                        case ...90:
-                            return FlippedStatus.myself
-                        case 91...:
-                            return FlippedStatus.opponent
-                        default:
-                            return FlippedStatus.myself
-                        }
-                    }()
+                    // 실제 뷰에서 사용하는 부분은 Main Queue에서 업데이트
+                    DispatchQueue.main.async {
+                        self.faced = {
+                            switch self.rotationDegree {
+                            case ...150:
+                                return FlippedStatus.myself
+                            case 151...300:
+                                return FlippedStatus.opponent
+                            default:
+                                return FlippedStatus.myself
+                            }
+                        }()
+                    }
                 }
             }
         } else {
@@ -69,5 +74,21 @@ class GyroScopeStore: ObservableObject {
 extension Double {
     func toDegrees() -> Double {
         return 180 / Double.pi * self
+    }
+}
+
+
+// Rotation을 테스트하기 위한 앱
+struct RotationTestView: View {
+    @StateObject private var gyroStore: GyroScopeStore = GyroScopeStore()
+    
+    var body: some View {
+        VStack {
+            Text(gyroStore.faced.rawValue)
+//            Text("\(gyroStore.rotationDegree)")
+        }
+        .onAppear {
+            gyroStore.startDeviceMotion()
+        }
     }
 }

--- a/talklat/talklat/Sources/Views/TKIntroView.swift
+++ b/talklat/talklat/Sources/Views/TKIntroView.swift
@@ -26,7 +26,7 @@ struct TKIntroView: View {
             }
         }
         .onAppear {
-            gyroMotionStore.startDeviceMotion()
+            gyroMotionStore.detectDeviceMotion()
         }
         .onChange(of: gyroMotionStore.faced) { facedStatus in
             switch facedStatus {


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
![advancedGyro](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/22471820/75420671-8387-4a78-acfd-334d504114f4)


| ⚒️ Title | `Advance Gyro Feature` | 
| :--- | :--- |
| 📜 **Description** | 자이로스코프를 개선 및 안정화해서 안정적인 flip 제스쳐와 앱 퍼포먼스를 개선할려고 노력했습니다. |
| 📌 **Issue Number** | #24|
| ![](https://img.shields.io/badge/-black?logo=figma)**Figma** | [Link](https://www.figma.com/file/Mb450yYTvio6Q9y6d0otwv/%F0%9F%8D%8EALLWAY-Team?type=design&node-id=1-4&mode=design) |
| ![](https://img.shields.io/badge/-black?logo=notion)**Notion Card** | [Link](https://www.notion.so/yenchoichoi/Gyro-11c39b920b7148718afed69ad3eba5a1) |

---

## 작업 사항
<!-- 1. MainIntroView의 ScrollView 구현 -->
1. 작업 내용


### `Logics`
  - Gyro가 pitch에 이제 거의 영향을 받지 않게 설정했습니다. 특히 상대방을 향한 화면일떄는 거의 -180~+180도에 거의 대응이 가능해요. 리서치를 통해서 Yaw 혹은 Roll만 측정하는게 아니라, Yaw, Roll, Pitch 3가지를 다 고려해야한다는걸 파악해서 적용했습니다. 이로 인해 store안에 새로운 변수인 rotationDegree가 만들어졌습니다. 세부적인 수치는 추후에 계속 해보면서 motionStatusSetter() 메서드 안에서 조정할 수 있을것 같습니다.
 ```swift
self.rotationDegree = abs(validData.attitude.pitch.toDegrees()) + abs(validData.attitude.roll.toDegrees()) + abs(validData.attitude.yaw.toDegrees())
.
.
.
private func motionStatusSetter(_ rotationDegree: Double) -> FlippedStatus {
        switch rotationDegree {
        case ...150:
            return FlippedStatus.myself
        case 151...300:
            return FlippedStatus.opponent
        default:
            return FlippedStatus.myself
        }
    }
```

- 찰랑군께서 언급해주신 https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/pull/11#issuecomment-1751940564 이슈를 어느정도 해결한것 같습니다. 기존의 code에서는 main queue에서 계속해서 측정이 일어났는데, 개선된 코드에서는 OperationQueue를 새로 생성해서 이 안에서 CoreMotion이 지속적인 측정을 하고 store 안의 값을 변경합니다. main view에서 쓰는 faced 변수는 DispatchQueue.main.async{...} 안에서 변경이 일어납니다.

```swift
private let queue: OperationQueue = OperationQueue()
.
.
.
self.motionManager.startDeviceMotionUpdates(
    using: .xArbitraryCorrectedZVertical,
    to: queue
)
.
.
.
DispatchQueue.main.async {
    self.faced = self.motionStatusSetter(self.rotationDegree)
}
```

---

## 작업 결과
<!-- 이미지, gif 등을 캡쳐하여 첨부합니다. -->
<!-- 해당 섹션은 필수가 아닙니다! -->

---

#### 기타 공유사항
- 현재 rotationDegree가 150~300정도면 상대방을 보여주는 화면이라고 판단하고 있습니다. 근데 내가 보고 있는 화면에서 화면을 위로 돌리면 잠깐 상대방이 보는 화면으로 갔다가 다시 돌아오는 현상이 있습니다. 그 이유는 나를 정면으로 보는 화면은 20정도의 rotationDegree인데 화면을 위로 올리다보면 값이 순식간에 400으로 튀어요. 이 부분은 아직 고민중인데 내가 보는 화면이라 괜찮지 않을까... 싶기도 합니다.
- state가 딱 변화하는 순간에 combine의 debounce를 이용해서 신호를 딱 주고 싶긴한데 이건 우선순위가 높지는 않은것 같아서 추후 스프린트로 미루도록 하겠습니다.
- 추가적으로 우리 팀의 컨텍스트가 올리브영이나 러쉬라면 돌아다니면서 이야기를 주고 받을 수 있는데, 현재는 손목을 돌리는게 아니라 몸을 회전시켜도 같은 플립이 일어납니다. 이것을 해결하기 위한 방법을 고민중에 있습니다 :)
