### PR TITLE
Fix/#26 QuestionText와 GuidingMessage 관련 UX/UI 수정 작업

### DIFF
--- a/talklat/talklat/Sources/Stores/AppViewStore.swift
+++ b/talklat/talklat/Sources/Stores/AppViewStore.swift
@@ -55,6 +55,7 @@ final class AppViewStore: ObservableObject {
     }
     
     public func onRecordingViewAppear() {
+        // TODO: 추후 Transcript 를 배열 등으로 저장하게 되면 해당 속성의 count 등으로 로직 업데이트 예정
         if !hasGuidingMessageShown,
            answeredText != nil {
             hasGuidingMessageShown = true
@@ -67,11 +68,6 @@ final class AppViewStore: ObservableObject {
         } else {
             questionText = str
         }
-    }
-    
-    public func hasAnsweredText() -> Bool {
-        if answeredText != nil { return true }
-        else { return false }
     }
 }
 

--- a/talklat/talklat/Sources/Stores/AppViewStore.swift
+++ b/talklat/talklat/Sources/Stores/AppViewStore.swift
@@ -17,6 +17,7 @@ final class AppViewStore: ObservableObject {
     @Published private(set) var questionText: String
     @Published private(set) var answeredText: String?
     @Published private(set) var currentAuthStatus: AuthStatus = .authIncompleted
+    @Published private(set) var hasGuidingMessageShown: Bool = false
     
     public let questionTextLimit: Int = 55
     
@@ -47,6 +48,18 @@ final class AppViewStore: ObservableObject {
     public func removeQuestionTextButtonTapped() {
         questionText = ""
     }
+
+    public func onWritingViewAppear() {
+        if questionText.isEmpty { }
+        else { questionText = "" }
+    }
+    
+    public func onRecordingViewAppear() {
+        if !hasGuidingMessageShown,
+           answeredText != nil {
+            hasGuidingMessageShown = true
+        }
+    }
     
     public func bindingTextField(_ str: String) {
         if str.count > questionTextLimit {
@@ -54,6 +67,11 @@ final class AppViewStore: ObservableObject {
         } else {
             questionText = str
         }
+    }
+    
+    public func hasAnsweredText() -> Bool {
+        if answeredText != nil { return true }
+        else { return false }
     }
 }
 

--- a/talklat/talklat/Sources/Views/TKRecordingView.swift
+++ b/talklat/talklat/Sources/Views/TKRecordingView.swift
@@ -30,7 +30,8 @@ struct TKRecordingView: View {
                         )
                 }
                 
-                if speechRecognizeManager.transcript == "" {
+                if speechRecognizeManager.transcript == "",
+                   !appViewStore.hasGuidingMessageShown {
                     guideMessageBuilder()
                         .transition(
                             .move(edge: .bottom)
@@ -57,6 +58,7 @@ struct TKRecordingView: View {
             }
         }
         .onAppear {
+            appViewStore.onRecordingViewAppear()
             speechRecognizeManager.startTranscribing()
         }
         .onChange(of: appViewStore.communicationStatus) { communicationStatus in

--- a/talklat/talklat/Sources/Views/TKWritingView.swift
+++ b/talklat/talklat/Sources/Views/TKWritingView.swift
@@ -82,6 +82,9 @@ struct TKWritingView: View {
                 .frame(maxHeight: 60)
         }
         .frame(maxHeight: .infinity)
+        .onAppear {
+            appViewStore.onWritingViewAppear()
+        }
     }
     
     // MARK: - METHODS


### PR DESCRIPTION
## 개요 및 관련 이슈
| ⚒️ Title | `QuestionText와 AnsweredText 관련 UX/UI 수정` | 
| :--- | :--- |
| 📜 **Description** | QuestionText를 지우고 GuidingMessage를 숨기는 UX 추가 |
| 📌 **Issue Number** | #26  |
| ![](https://img.shields.io/badge/-black?logo=figma)**Figma** | _ |
| ![](https://img.shields.io/badge/-black?logo=notion)**Notion Card** | _ |

---

## 작업 사항
1. 이전에 작성한 `QuestionText`가 있을 때, `TKWritingView` 진입 시점에 삭제하고 `""`로 할당합니다.
2. `GuidingMessage`가 보여진 적이 있을 때, 다시 나타나지 않도록 수정합니다.

---

## 작업 결과
<!-- 이미지, gif 등을 캡쳐하여 첨부합니다. -->
<!-- 해당 섹션은 필수가 아닙니다! -->

| 이전 QuestionText를 완전히 빈 칸으로 초기화 |
| ----- |
| ![Simulator Screen Recording - iPhone 14 Pro - 2023-10-16 at 18 04 19](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/7e3632c8-e089-4abc-a799-d0959552ace6) |
---

#### 기타 공유사항
<!-- 야기될 수 있는 사이드 이펙트, 조사가 필요한 내용 등을 작성합니다. --> 
1. 현재 `AnsweredText`는 단일 스트링 타입입니다. 추후 @MADElinessss 의 `AnsweredText` 배열 처리 작업이 완료된 후 작업을 점검합니다.
    - cc. @MADElinessss 