### PR TITLE
Feat/#28 implement haptic feedback

### DIFF
--- a/talklat/talklat.xcodeproj/project.pbxproj
+++ b/talklat/talklat.xcodeproj/project.pbxproj
@@ -531,7 +531,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"talklat/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = 67M6ZS7KS6;
+				DEVELOPMENT_TEAM = CZH2CMCGCZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_LSApplicationCategoryType = "Privacy - Speech Recognition Usage Description";
@@ -563,7 +563,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"talklat/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = 67M6ZS7KS6;
+				DEVELOPMENT_TEAM = CZH2CMCGCZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_LSApplicationCategoryType = "Privacy - Speech Recognition Usage Description";

--- a/talklat/talklat.xcodeproj/project.pbxproj
+++ b/talklat/talklat.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		7EF737972AD43EE000FCBA21 /* TKTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF737962AD43EE000FCBA21 /* TKTextField.swift */; };
 		7EFA2C282AD506050013B533 /* talklatApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17C42ACE8AEC00E904E5 /* talklatApp.swift */; };
 		7EFA2C2B2AD51FC80013B533 /* Double+Degree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFA2C2A2AD51FC80013B533 /* Double+Degree.swift */; };
+		CEF43C482ADA97FF00DE02A9 /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF43C472ADA97FF00DE02A9 /* HapticManager.swift */; };
 		EF67C64B2ACEB67000C1074E /* SpeechRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF67C64A2ACEB67000C1074E /* SpeechRecognizer.swift */; };
 		EF67C6532AD13BF700C1074E /* AppRootManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF67C6522AD13BF700C1074E /* AppRootManager.swift */; };
 		EF67C6572AD1414300C1074E /* AuthorizationRequestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF67C6562AD1414300C1074E /* AuthorizationRequestView.swift */; };
@@ -63,6 +64,7 @@
 		7EF737932AD3DE5600FCBA21 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		7EF737962AD43EE000FCBA21 /* TKTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKTextField.swift; sourceTree = "<group>"; };
 		7EFA2C2A2AD51FC80013B533 /* Double+Degree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Degree.swift"; sourceTree = "<group>"; };
+		CEF43C472ADA97FF00DE02A9 /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
 		EF67C64A2ACEB67000C1074E /* SpeechRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognizer.swift; sourceTree = "<group>"; };
 		EF67C6522AD13BF700C1074E /* AppRootManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRootManager.swift; sourceTree = "<group>"; };
 		EF67C6562AD1414300C1074E /* AuthorizationRequestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationRequestView.swift; sourceTree = "<group>"; };
@@ -220,6 +222,7 @@
 			children = (
 				EF67C6522AD13BF700C1074E /* AppRootManager.swift */,
 				EF67C64A2ACEB67000C1074E /* SpeechRecognizer.swift */,
+				CEF43C472ADA97FF00DE02A9 /* HapticManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -356,6 +359,7 @@
 			files = (
 				7EFA2C282AD506050013B533 /* talklatApp.swift in Sources */,
 				7EF737912AD3DCF900FCBA21 /* TKRecordingView.swift in Sources */,
+				CEF43C482ADA97FF00DE02A9 /* HapticManager.swift in Sources */,
 				7E8906412ACEA31500C9947A /* TKIntroView.swift in Sources */,
 				7EF7378F2AD3DCE500FCBA21 /* TKWritingView.swift in Sources */,
 				7EF737942AD3DE5600FCBA21 /* Constants.swift in Sources */,

--- a/talklat/talklat/Sources/Managers/HapticManager.swift
+++ b/talklat/talklat/Sources/Managers/HapticManager.swift
@@ -1,0 +1,22 @@
+//
+//  HapticManager.swift
+//  talklat
+//
+//  Created by user on 2023/10/14.
+//
+
+import SwiftUI
+
+class HapticManager {
+    static let sharedInstance = HapticManager()
+    
+    private func notification(_ type: UINotificationFeedbackGenerator.FeedbackType) {
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(type)
+    }
+    
+    private func impact(_ style: UIImpactFeedbackGenerator.FeedbackStyle) {
+        let generator = UIImpactFeedbackGenerator(style: style)
+        generator.impactOccurred()
+    }
+}

--- a/talklat/talklat/Sources/Managers/HapticManager.swift
+++ b/talklat/talklat/Sources/Managers/HapticManager.swift
@@ -5,28 +5,114 @@
 //  Created by user on 2023/10/14.
 //
 
+import CoreHaptics
 import SwiftUI
 
 class HapticManager {
-    static let sharedInstance = HapticManager()
-    
-    func notification(_ type: UINotificationFeedbackGenerator.FeedbackType) {
-        let generator = UINotificationFeedbackGenerator()
-        generator.notificationOccurred(type)
+    enum HapticStyle: String {
+        case sttToText
+        case textToStt
     }
     
-    func impact(_ style: UIImpactFeedbackGenerator.FeedbackStyle) {
-        let generator = UIImpactFeedbackGenerator(style: style)
-        generator.impactOccurred()
+    static var sharedInstance: HapticManager = HapticManager()
+    var engine: CHHapticEngine?
+    
+    init() {
+        prepareHapticEngine()
+    }
+    
+    /// hapticEngine을 준비하는 함수
+    func prepareHapticEngine() {
+        guard CHHapticEngine.capabilitiesForHardware().supportsHaptics else { return }
+        do {
+            self.engine?.stop()
+            self.engine = try CHHapticEngine()
+            self.engine?.playsHapticsOnly = true
+            self.engine?.isAutoShutdownEnabled = true
+            self.engine?.stoppedHandler = { reason in
+                print("\(reason)")
+            }
+            self.engine?.resetHandler = {
+                do {
+                    print("reseting core haptic engine")
+                    try self.engine?.start()
+                } catch {
+                    print("cannot reset core haptic engine")
+                }
+            }
+        } catch {
+            // 정상적으로 햅틱 엔진 시작 불가
+            //            fatalError("Cannot create haptic engine")
+            print("Cannot create haptic engine")
+        }
+    }
+    
+    /// 외부에서 Haptic에 접근하는 함수
+    func generateHaptic(_ style: HapticStyle) {
+        let pattern = self.generateHapticPattern(style)
+        do {
+            try self.playHaptic(pattern)
+        } catch {
+            print("Cannot play haptic")
+        }
+    }
+    
+    /// 햅틱 패턴을 만들어내는 함수
+    private func generateHapticPattern(_ style: HapticStyle) -> CHHapticPattern? {
+        switch style {
+        // rigid twice
+        case .sttToText:
+            let intensity = CHHapticEventParameter(parameterID: .hapticIntensity, value: 2)
+            let sharpness = CHHapticEventParameter(parameterID: .hapticSharpness, value: 1)
+            
+            
+            let firstEvent = CHHapticEvent(eventType: .hapticTransient, parameters: [intensity, sharpness], relativeTime: 0)
+            let secondEvent = CHHapticEvent(eventType: .hapticTransient, parameters: [intensity, sharpness], relativeTime: 0.1)
+            
+            let pattern = try? CHHapticPattern(events: [firstEvent, secondEvent], parameters: [])
+            return pattern
+            
+        // success
+        case .textToStt:
+            let firstIntensity = CHHapticEventParameter(parameterID: .hapticIntensity, value: 1)
+            let firstSharpness = CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.4)
+            let firstEvent = CHHapticEvent(eventType: .hapticTransient, parameters: [firstIntensity, firstSharpness], relativeTime: 0)
+            
+            let secondIntensity = CHHapticEventParameter(parameterID: .hapticIntensity, value: 2)
+            let secondSharpness = CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.8)
+            let secondEvent = CHHapticEvent(eventType: .hapticTransient, parameters: [secondIntensity, secondSharpness], relativeTime: 0.15)
+            
+            let pattern = try? CHHapticPattern(events: [firstEvent, secondEvent], parameters: [])
+            return pattern
+            
+        }
+    }
+    
+    /// pattern에 따라 햅틱을 실행시키는 함수
+    private func playHaptic(_ pattern: CHHapticPattern?) throws {
+        // Generate haptic using the pattern above
+        guard let givenPattern = pattern else { return }
+        
+        let player = try self.engine?.makePlayer(with: givenPattern)
+        try player?.start(atTime: 0)
     }
 }
 
 
+// TestView for haptic
 struct HapticTestView: View {
-    let hapticManager: HapticManager = HapticManager()
     var body: some View {
-        Button("Haptic Test") {
-            hapticManager.impact(.rigid)
+        VStack(spacing: 40) {
+            Button("rigid 2번") {
+                HapticManager.sharedInstance.generateHaptic(.sttToText)
+            }
+            
+            Button("success") {
+                HapticManager.sharedInstance.generateHaptic(.textToStt)
+            }
+        }
+        .onAppear {
+            HapticManager.sharedInstance.prepareHapticEngine()
         }
     }
 }

--- a/talklat/talklat/Sources/Managers/HapticManager.swift
+++ b/talklat/talklat/Sources/Managers/HapticManager.swift
@@ -10,13 +10,23 @@ import SwiftUI
 class HapticManager {
     static let sharedInstance = HapticManager()
     
-    private func notification(_ type: UINotificationFeedbackGenerator.FeedbackType) {
+    func notification(_ type: UINotificationFeedbackGenerator.FeedbackType) {
         let generator = UINotificationFeedbackGenerator()
         generator.notificationOccurred(type)
     }
     
-    private func impact(_ style: UIImpactFeedbackGenerator.FeedbackStyle) {
+    func impact(_ style: UIImpactFeedbackGenerator.FeedbackStyle) {
         let generator = UIImpactFeedbackGenerator(style: style)
         generator.impactOccurred()
+    }
+}
+
+
+struct HapticTestView: View {
+    let hapticManager: HapticManager = HapticManager()
+    var body: some View {
+        Button("Haptic Test") {
+            hapticManager.impact(.rigid)
+        }
     }
 }

--- a/talklat/talklat/Sources/Managers/SpeechRecognizer.swift
+++ b/talklat/talklat/Sources/Managers/SpeechRecognizer.swift
@@ -119,6 +119,8 @@ final class SpeechRecognizer: ObservableObject {
             options: .notifyOthersOnDeactivation
         )
         
+        try audioSession.setAllowHapticsAndSystemSoundsDuringRecording(true)
+        
         let inputNode = audioEngine.inputNode
         let recordingFormat = inputNode.outputFormat(forBus: 0)
         inputNode.installTap(

--- a/talklat/talklat/Sources/Views/TKIntroView.swift
+++ b/talklat/talklat/Sources/Views/TKIntroView.swift
@@ -32,10 +32,12 @@ struct TKIntroView: View {
             switch facedStatus {
             case .myself:
                 appViewStore.communicationStatusSetter(.writing)
+                HapticManager.sharedInstance.generateHaptic(.sttToText)
             case .opponent:
                 withAnimation {
                     appViewStore.communicationStatusSetter(.recording)
                 }
+                HapticManager.sharedInstance.generateHaptic(.textToStt)
             }
         }
     }

--- a/talklat/talklat/Sources/Views/TKIntroView.swift
+++ b/talklat/talklat/Sources/Views/TKIntroView.swift
@@ -32,12 +32,12 @@ struct TKIntroView: View {
             switch facedStatus {
             case .myself:
                 appViewStore.communicationStatusSetter(.writing)
-                HapticManager.sharedInstance.generateHaptic(.sttToText)
+                HapticManager.sharedInstance.generateHaptic(.rigidTwice)
             case .opponent:
                 withAnimation {
                     appViewStore.communicationStatusSetter(.recording)
                 }
-                HapticManager.sharedInstance.generateHaptic(.textToStt)
+                HapticManager.sharedInstance.generateHaptic(.success)
             }
         }
     }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->
<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `Implement Haptic Feedback` | 
| :--- | :--- |
| 📜 **Description** | Haptic Manager 및 전환에 대한 햅틱 피드백을 구현합니다|
| 📌 **Issue Number** | #28 |
| ![](https://img.shields.io/badge/-black?logo=figma)**Figma** | [Link](https://www.figma.com/file/Mb450yYTvio6Q9y6d0otwv/%F0%9F%8D%8EALLWAY-Team?type=design&node-id=1-4&mode=design)|
| ![](https://img.shields.io/badge/-black?logo=notion)**Notion Card** | [Link](<!-- URL -->) |

---

## 작업 사항
<!-- 1. MainIntroView의 ScrollView 구현 -->
1. CoreHaptic을 이용한 HapticManager 구현
- 기존에 한번은 UIFeedbackGenerator를 이용해서 간단하게 구현하고 커밋을 했었는데, STT변환을 할때 dynamic haptic을 집어넣기 위해서 CoreHaptic을 채택했습니다.
- 일단은 HapticManager type에 싱글톤 형태로 구현해놓은 상태인데, 어떤 방법이 좋을지는 이야기해보고 싶습니다.
- 현재는 2분정도 가만히 있으면 engine이 멈추는 상태인데, 이것도 추후에 변경될 수 있을것 같습니다.



2. 2종류의 Haptic 구현
- CoreHaptic으로 Transient한 햅틱을 만들기 위해서 2단계로 메서드를 나눠놨습니다. 첫번째는 햅틱 패턴을 만드는것이고 두번째는 engine에 패턴을 넣고 실행시키는 것입니다.

---
### `Logics`
- 싱글톤으로 구현해놔서 어디서든 HapticManager.sharedInstace로 싱글톤 객체를 사용할 수 있습니다.
```swift
static var sharedInstance: HapticManager = HapticManager()
```

- 외부에서 접근가능한 메서드는 현재는 prepareHapticEngine()와 generateHaptic()입니다. prepareHapticEngine()메서드가 접근 가능한 이유는 2분정도 지났을때 engine이 꺼지면 다시 재작동해야할 수 있기때문에 우선은 접근제어자를 붙혀놓지 않았습니다. 만약 추후에 접근할 일이 없다면 private 을 붙혀도 될 것 같습니다.
```swift
func generateHaptic(_ style: HapticStyle) {
        let pattern = self.generateHapticPattern(style)
        do {
            try self.playHaptic(pattern)
        } catch {
            print("Cannot play haptic")
        }
    }
```

- generateHaptic은 두부분으로 나눠진 함수입니다. 패턴을 만들어내는 generateHapticPattern함수와 만들어진 패턴을 실행시키는 playHaptic함수입니다.

- 햅틱 패턴을 만들어 내는 generateHapticPattern 메서드에서 현재는 모든 intensity와 sharpness에 값을 일일이 넣어주면서 만들어내고 있습니다. 추후에 이 부분을 다음과 같이 enum으로 만들어서 조금 더 깔끔하게 나타낼 수 있지 않을까 하는 생각이 있습니다.
```swift
// 현재
let intensity = CHHapticEventParameter(parameterID: .hapticIntensity, value: 2)
let sharpness = CHHapticEventParameter(parameterID: .hapticSharpness, value: 1)

// 추후
enum sharpness {
    case high
    case low

    fileprivate var sharpnessParameter: CHHapticEventParameter {
        switch self {
            case .high: return CHHapticEventParamater(...)
        }
    }
}
```

- 햅틱을 주는 시점은 TKIntroView에서 onchange로 GyroMotionStore.faced가 변경되는 31번째 블록에서 각각의 case마다 맞는 햅틱을 줄려고 했습니다. 이 부분은 논의를 통해서 변경될 수 있을것 같습니다.
```swift
.onChange(of: gyroMotionStore.faced) { facedStatus in
            switch facedStatus {
            case .myself:
                appViewStore.communicationStatusSetter(.writing)
                HapticManager.sharedInstance.generateHaptic(.sttToText) // New
            case .opponent:
                withAnimation {
                    appViewStore.communicationStatusSetter(.recording)
                }
                HapticManager.sharedInstance.generateHaptic(.textToStt) // New
            }
        }
```

---

## 작업 결과
<!-- 이미지, gif 등을 캡쳐하여 첨부합니다. -->
<!-- 해당 섹션은 필수가 아닙니다! -->

---

#### 기타 공유사항
- pr을 쓰다보니까 깨달은건데 init 부분에 closure가 너무 많이 들어가서 지져분해보이네요. 이 부분은 따로 메서드로 빼서 작성할 수 있겠네요
- HapticEngine을 구현하고 나서 테스트를 해봤는데 처음 한번만 햅틱이 울리고 그 다음은 계속해서 울리지 않는 상황이 발생했습니다. 조사결과 apple에서는 AudioSesison에서 recoding을 할때는 haptic이 recording을 방해할 수 있어서 기본적으로는 막아놓는다고 합니다. 이를 해결하기 위해 SpeechRecognizer 파일의 122번째줄에 .setAllowHapticsAndSystemSoundsDuringRecording(true) 옵션을 줬습니다. SpeechRecognizer 파트를 담당하시는분들은 참고하시면 좋을것 같습니다. @MADElinessss  @lianne-b 