### PR TITLE
Feat/#31 TKHistoryView를 구현합니다.

### DIFF
--- a/talklat/talklat.xcodeproj/project.pbxproj
+++ b/talklat/talklat.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		7EA8A78B2AD502D600AFD687 /* GyroScopeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA8A78A2AD502D600AFD687 /* GyroScopeStore.swift */; };
 		7ED9AA082ACE8E4300B1EA4E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E8D17CB2ACE8AED00E904E5 /* Preview Assets.xcassets */; };
 		7ED9AA092ACE8E4300B1EA4E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E8D17C82ACE8AED00E904E5 /* Assets.xcassets */; };
+		7EE087E82ADD4FAE00E07720 /* TKHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE087E72ADD4FAE00E07720 /* TKHistoryView.swift */; };
 		7EF7378C2AD3C87700FCBA21 /* AppViewStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF7378B2AD3C87700FCBA21 /* AppViewStore.swift */; };
 		7EF7378F2AD3DCE500FCBA21 /* TKWritingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF7378E2AD3DCE500FCBA21 /* TKWritingView.swift */; };
 		7EF737912AD3DCF900FCBA21 /* TKRecordingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF737902AD3DCF900FCBA21 /* TKRecordingView.swift */; };
@@ -57,6 +58,7 @@
 		7E8D17DF2ACE8AED00E904E5 /* talklatUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = talklatUITests.swift; sourceTree = "<group>"; };
 		7E8D17E12ACE8AED00E904E5 /* talklatUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = talklatUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		7EA8A78A2AD502D600AFD687 /* GyroScopeStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GyroScopeStore.swift; sourceTree = "<group>"; };
+		7EE087E72ADD4FAE00E07720 /* TKHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKHistoryView.swift; sourceTree = "<group>"; };
 		7EF7378B2AD3C87700FCBA21 /* AppViewStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppViewStore.swift; sourceTree = "<group>"; };
 		7EF7378E2AD3DCE500FCBA21 /* TKWritingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKWritingView.swift; sourceTree = "<group>"; };
 		7EF737902AD3DCF900FCBA21 /* TKRecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKRecordingView.swift; sourceTree = "<group>"; };
@@ -177,6 +179,7 @@
 				7EF737902AD3DCF900FCBA21 /* TKRecordingView.swift */,
 				EF67C6562AD1414300C1074E /* AuthorizationRequestView.swift */,
 				57E76EB62ACEC91A00D79553 /* StaffSpeechView.swift */,
+				7EE087E72ADD4FAE00E07720 /* TKHistoryView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -364,6 +367,7 @@
 				7EF737972AD43EE000FCBA21 /* TKTextField.swift in Sources */,
 				EF67C6532AD13BF700C1074E /* AppRootManager.swift in Sources */,
 				57E76EB72ACEC91A00D79553 /* StaffSpeechView.swift in Sources */,
+				7EE087E82ADD4FAE00E07720 /* TKHistoryView.swift in Sources */,
 				EF67C64B2ACEB67000C1074E /* SpeechRecognizer.swift in Sources */,
 				EF67C6572AD1414300C1074E /* AuthorizationRequestView.swift in Sources */,
 				7EA8A78B2AD502D600AFD687 /* GyroScopeStore.swift in Sources */,

--- a/talklat/talklat/Sources/Views/TKHistoryView.swift
+++ b/talklat/talklat/Sources/Views/TKHistoryView.swift
@@ -76,6 +76,11 @@ struct TKHistoryView: View {
                     .background {
                         Rectangle()
                             .fill(Color.white)
+                            .shadow(
+                                color: Color(.systemGray4),
+                                radius: 30,
+                                y: -1
+                            )
                     }
             }
             .frame(

--- a/talklat/talklat/Sources/Views/TKHistoryView.swift
+++ b/talklat/talklat/Sources/Views/TKHistoryView.swift
@@ -1,0 +1,20 @@
+//
+//  TKHistoryView.swift
+//  talklat
+//
+//  Created by Celan on 2023/10/16.
+//
+
+import SwiftUI
+
+struct TKHistoryView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct TKHistoryView_Previews: PreviewProvider {
+    static var previews: some View {
+        TKHistoryView()
+    }
+}

--- a/talklat/talklat/Sources/Views/TKHistoryView.swift
+++ b/talklat/talklat/Sources/Views/TKHistoryView.swift
@@ -8,13 +8,101 @@
 import SwiftUI
 
 struct TKHistoryView: View {
+    @ObservedObject var appViewStore: AppViewStore
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ZStack {
+            ScrollView {
+                // TODO: - ForEach의 data 아규먼트 수정
+                // TODO: - 각 Color 값을 디자인 시스템 값으로 추후 수정
+                ForEach(0..<100) { int in
+                    if int % 2 == 0 {
+                        VStack(alignment: .leading) {
+                            Image(systemName: "waveform.circle.fill")
+                                .resizable()
+                                .frame(width: 24, height: 24)
+                                .foregroundColor(Color(.systemGray))
+                                .padding(.leading, 4)
+                            
+                            Text("일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠")
+                                .font(.headline)
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 8)
+                                .background {
+                                    RoundedRectangle(cornerRadius: 12)
+                                        .fill(Color(.white))
+                                        .frame(maxHeight: 100)
+                                }
+                        }
+                        .padding(.horizontal, 24)
+                        
+                    } else {
+                        Text("일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠")
+                            .font(.subheadline)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .background {
+                                RoundedRectangle(cornerRadius: 12)
+                                    .fill(Color(.systemGray4))
+                                    .frame(maxHeight: 100)
+                            }
+                            .padding(.trailing, 24)
+                            .padding(.leading, 68)
+                            .padding(.top, 32)
+                    }
+                }
+            }
+            .padding(.top, 16)
+            .background { Color(.systemGray6 )}
+            
+            VStack {
+                VStack(spacing: 12) {
+                    Text("텍스트 작성 페이지로 돌아가기")
+                        .font(.system(size: 12, weight: .bold))
+                        .bold()
+                        .padding(.top, 24)
+                    
+                    Image(systemName: "chevron.compact.down")
+                        .resizable()
+                        .frame(width: 32, height: 10)
+                        .padding(.bottom, 10)
+                }
+                    .frame(
+                        maxWidth: .infinity,
+                        maxHeight: 100,
+                        alignment: .top
+                    )
+                    .foregroundColor(Color(.systemGray))
+                    .background {
+                        Rectangle()
+                            .fill(Color.white)
+                    }
+            }
+            .frame(
+                maxHeight: .infinity,
+                alignment: .bottom
+            )
+        }
+        .ignoresSafeArea(edges: .bottom)
+        .navigationTitle("히스토리")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(
+            Color(.systemGray6),
+            for: .navigationBar
+        )
+        .toolbarBackground(
+            .visible,
+            for: .navigationBar
+        )
     }
 }
 
 struct TKHistoryView_Previews: PreviewProvider {
     static var previews: some View {
-        TKHistoryView()
+        NavigationStack {
+            TKHistoryView(appViewStore: .makePreviewStore(condition: { store in
+                
+            }))
+        }
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->
<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `TKHistoryView 구현` | 
| :--- | :--- |
| 📜 **Description** | TKHistoryView를 구현합니다. |
| 📌 **Issue Number** | #31  |
| ![](https://img.shields.io/badge/-black?logo=figma) **Figma** | [Link](https://www.figma.com/file/Mb450yYTvio6Q9y6d0otwv/%F0%9F%8D%8EALLWAY-Team?type=design&node-id=1113-2943&mode=design) |
| ![](https://img.shields.io/badge/-black?logo=notion) **Notion Card** | _ |

---

## 작업 사항
<!-- 1. MainIntroView의 ScrollView 구현 -->
1. TKHistoryView를 구현합니다.
  - `.safeAreaInset()` 대신 모든 화면에서 아래에 위치하는 `VStack`으로 View 대응
  - 이유: TKIntroView와의 Scroll Transition이 일관적으로 유지되도록

### `Logics`
- UI 작업에 특별한 로직이 없어서 생략합니다.

---

## 작업 결과
<!-- 이미지, gif 등을 캡쳐하여 첨부합니다. -->
<!-- 해당 섹션은 필수가 아닙니다! -->
| 작업 결과 |
|---|
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/36674355-48b5-408c-937b-652f5856fb2f" width="350px"> |

---

#### 기타 공유사항
1. 현재 `TKHistoryView`는 `TKIntroView`와 연결되어 있지 않습니다. 추후 스크롤 Transition으로 `TKIntroView`와 연결합니다.
  - cc. @lianne-b 
2. 컬러 디자인 시스템이 없기 때문에 추후 일괄 수정 예정입니다.
3. 현재 `TKHistoryView`는 mock-up 되어 있는 텍스트를 보여주고 있습니다. History 타입이 완성되면 `ForEach`의 아규먼트를 대체합니다.
  - cc. @MADElinessss 
