### PR TITLE
Feat/#30 feat historyview conversation

### DIFF
--- a/talklat/talklat.xcodeproj/project.pbxproj
+++ b/talklat/talklat.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		57806D712ADC5D19003A7B19 /* TKHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57806D702ADC5D19003A7B19 /* TKHistoryView.swift */; };
+		57806D712ADC5D19003A7B19 /* TestHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57806D702ADC5D19003A7B19 /* TestHistoryView.swift */; };
 		57806D722ADEB8FD003A7B19 /* TKWritingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF7378E2AD3DCE500FCBA21 /* TKWritingView.swift */; };
 		57E76EB72ACEC91A00D79553 /* StaffSpeechView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E76EB62ACEC91A00D79553 /* StaffSpeechView.swift */; };
 		7E8906412ACEA31500C9947A /* TKIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8906402ACEA31500C9947A /* TKIntroView.swift */; };
@@ -46,7 +46,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		57806D702ADC5D19003A7B19 /* TKHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKHistoryView.swift; sourceTree = "<group>"; };
+		57806D702ADC5D19003A7B19 /* TestHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHistoryView.swift; sourceTree = "<group>"; };
 		57E76EB62ACEC91A00D79553 /* StaffSpeechView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaffSpeechView.swift; sourceTree = "<group>"; };
 		7E8906402ACEA31500C9947A /* TKIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKIntroView.swift; sourceTree = "<group>"; };
 		7E8D17C12ACE8AEC00E904E5 /* talklat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = talklat.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -179,7 +179,7 @@
 				7EF737902AD3DCF900FCBA21 /* TKRecordingView.swift */,
 				EF67C6562AD1414300C1074E /* AuthorizationRequestView.swift */,
 				57E76EB62ACEC91A00D79553 /* StaffSpeechView.swift */,
-				57806D702ADC5D19003A7B19 /* TKHistoryView.swift */,
+				57806D702ADC5D19003A7B19 /* TestHistoryView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -367,7 +367,7 @@
 				7EF737972AD43EE000FCBA21 /* TKTextField.swift in Sources */,
 				EF67C6532AD13BF700C1074E /* AppRootManager.swift in Sources */,
 				57E76EB72ACEC91A00D79553 /* StaffSpeechView.swift in Sources */,
-				57806D712ADC5D19003A7B19 /* TKHistoryView.swift in Sources */,
+				57806D712ADC5D19003A7B19 /* TestHistoryView.swift in Sources */,
 				EF67C64B2ACEB67000C1074E /* SpeechRecognizer.swift in Sources */,
 				EF67C6572AD1414300C1074E /* AuthorizationRequestView.swift in Sources */,
 				7EA8A78B2AD502D600AFD687 /* GyroScopeStore.swift in Sources */,

--- a/talklat/talklat.xcodeproj/project.pbxproj
+++ b/talklat/talklat.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		57806D712ADC5D19003A7B19 /* TKHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57806D702ADC5D19003A7B19 /* TKHistoryView.swift */; };
 		57E76EB72ACEC91A00D79553 /* StaffSpeechView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E76EB62ACEC91A00D79553 /* StaffSpeechView.swift */; };
 		7E8906412ACEA31500C9947A /* TKIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8906402ACEA31500C9947A /* TKIntroView.swift */; };
 		7E8D17D62ACE8AED00E904E5 /* talklatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17D52ACE8AED00E904E5 /* talklatTests.swift */; };
@@ -45,6 +46,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		57806D702ADC5D19003A7B19 /* TKHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKHistoryView.swift; sourceTree = "<group>"; };
 		57E76EB62ACEC91A00D79553 /* StaffSpeechView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaffSpeechView.swift; sourceTree = "<group>"; };
 		7E8906402ACEA31500C9947A /* TKIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKIntroView.swift; sourceTree = "<group>"; };
 		7E8D17C12ACE8AEC00E904E5 /* talklat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = talklat.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -177,6 +179,7 @@
 				7EF737902AD3DCF900FCBA21 /* TKRecordingView.swift */,
 				EF67C6562AD1414300C1074E /* AuthorizationRequestView.swift */,
 				57E76EB62ACEC91A00D79553 /* StaffSpeechView.swift */,
+				57806D702ADC5D19003A7B19 /* TKHistoryView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -364,6 +367,7 @@
 				7EF737972AD43EE000FCBA21 /* TKTextField.swift in Sources */,
 				EF67C6532AD13BF700C1074E /* AppRootManager.swift in Sources */,
 				57E76EB72ACEC91A00D79553 /* StaffSpeechView.swift in Sources */,
+				57806D712ADC5D19003A7B19 /* TKHistoryView.swift in Sources */,
 				EF67C64B2ACEB67000C1074E /* SpeechRecognizer.swift in Sources */,
 				EF67C6572AD1414300C1074E /* AuthorizationRequestView.swift in Sources */,
 				7EA8A78B2AD502D600AFD687 /* GyroScopeStore.swift in Sources */,
@@ -527,7 +531,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"talklat/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = CZH2CMCGCZ;
+				DEVELOPMENT_TEAM = MTUYFM4K8P;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_LSApplicationCategoryType = "Privacy - Speech Recognition Usage Description";
@@ -559,7 +563,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"talklat/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = CZH2CMCGCZ;
+				DEVELOPMENT_TEAM = MTUYFM4K8P;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_LSApplicationCategoryType = "Privacy - Speech Recognition Usage Description";

--- a/talklat/talklat.xcodeproj/project.pbxproj
+++ b/talklat/talklat.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		57806D712ADC5D19003A7B19 /* TKHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57806D702ADC5D19003A7B19 /* TKHistoryView.swift */; };
+		57806D722ADEB8FD003A7B19 /* TKWritingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF7378E2AD3DCE500FCBA21 /* TKWritingView.swift */; };
 		57E76EB72ACEC91A00D79553 /* StaffSpeechView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E76EB62ACEC91A00D79553 /* StaffSpeechView.swift */; };
 		7E8906412ACEA31500C9947A /* TKIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8906402ACEA31500C9947A /* TKIntroView.swift */; };
 		7E8D17D62ACE8AED00E904E5 /* talklatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17D52ACE8AED00E904E5 /* talklatTests.swift */; };
@@ -17,7 +18,6 @@
 		7ED9AA082ACE8E4300B1EA4E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E8D17CB2ACE8AED00E904E5 /* Preview Assets.xcassets */; };
 		7ED9AA092ACE8E4300B1EA4E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E8D17C82ACE8AED00E904E5 /* Assets.xcassets */; };
 		7EF7378C2AD3C87700FCBA21 /* AppViewStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF7378B2AD3C87700FCBA21 /* AppViewStore.swift */; };
-		7EF7378F2AD3DCE500FCBA21 /* TKWritingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF7378E2AD3DCE500FCBA21 /* TKWritingView.swift */; };
 		7EF737912AD3DCF900FCBA21 /* TKRecordingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF737902AD3DCF900FCBA21 /* TKRecordingView.swift */; };
 		7EF737942AD3DE5600FCBA21 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF737932AD3DE5600FCBA21 /* Constants.swift */; };
 		7EF737972AD43EE000FCBA21 /* TKTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF737962AD43EE000FCBA21 /* TKTextField.swift */; };
@@ -357,10 +357,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				57806D722ADEB8FD003A7B19 /* TKWritingView.swift in Sources */,
 				7EFA2C282AD506050013B533 /* talklatApp.swift in Sources */,
 				7EF737912AD3DCF900FCBA21 /* TKRecordingView.swift in Sources */,
 				7E8906412ACEA31500C9947A /* TKIntroView.swift in Sources */,
-				7EF7378F2AD3DCE500FCBA21 /* TKWritingView.swift in Sources */,
 				7EF737942AD3DE5600FCBA21 /* Constants.swift in Sources */,
 				7EF7378C2AD3C87700FCBA21 /* AppViewStore.swift in Sources */,
 				7EFA2C2B2AD51FC80013B533 /* Double+Degree.swift in Sources */,

--- a/talklat/talklat/Sources/Stores/AppViewStore.swift
+++ b/talklat/talklat/Sources/Stores/AppViewStore.swift
@@ -68,16 +68,10 @@ extension AppViewStore {
     
     public func questionTextSetter(_ str: String) {
         questionText = str
-        let newQuestion = HistoryItem(text: str, type: .question)
-        historyItems.append(newQuestion)
-
     }
     
     public func answeredTextSetter(_ str: String) {
         answeredText = str
-        let newAnswer = HistoryItem(text: str, type: .answer)
-        historyItems.append(newAnswer)
-
     }
     
     public func voiceRecordingAuthSetter(_ status: AuthStatus) {

--- a/talklat/talklat/Sources/Stores/AppViewStore.swift
+++ b/talklat/talklat/Sources/Stores/AppViewStore.swift
@@ -17,6 +17,7 @@ final class AppViewStore: ObservableObject {
     @Published private(set) var questionText: String
     @Published private(set) var answeredText: String?
     @Published private(set) var currentAuthStatus: AuthStatus = .authIncompleted
+    @Published var historyItems: [HistoryItem] = []
     
     public let questionTextLimit: Int = 55
     
@@ -67,10 +68,16 @@ extension AppViewStore {
     
     public func questionTextSetter(_ str: String) {
         questionText = str
+        let newQuestion = HistoryItem(text: str, type: .question)
+        historyItems.append(newQuestion)
+
     }
     
     public func answeredTextSetter(_ str: String) {
         answeredText = str
+        let newAnswer = HistoryItem(text: str, type: .answer)
+        historyItems.append(newAnswer)
+
     }
     
     public func voiceRecordingAuthSetter(_ status: AuthStatus) {

--- a/talklat/talklat/Sources/Stores/AppViewStore.swift
+++ b/talklat/talklat/Sources/Stores/AppViewStore.swift
@@ -39,6 +39,28 @@ final class AppViewStore: ObservableObject {
         }
     }
     
+    public func onWritingViewDisappear() {
+        // TKHistoryView로 user's text 전달
+        if !questionText.isEmpty {
+            let newHistoryItem = HistoryItem(
+                id: UUID(),
+                text: questionText,
+                type: .question
+            )
+            historyItems.append(newHistoryItem)
+        }
+        print(questionText)
+    }
+    
+    public func onRecordingViewDisappear(transcript: String) {
+        if let answeredText = answeredText,
+           !answeredText.isEmpty &&
+            !transcript.isEmpty {
+            let answerItem = HistoryItem(id: UUID(), text: answeredText, type: .answer)
+            historyItems.append(answerItem)
+        }
+    }
+    
     public func stopSpeechRecognizeButtonTapped() {
         withAnimation(.easeIn(duration: 0.75)) {
             communicationStatus = .writing

--- a/talklat/talklat/Sources/Views/TKHistoryView.swift
+++ b/talklat/talklat/Sources/Views/TKHistoryView.swift
@@ -7,39 +7,43 @@
 
 import SwiftUI
 
-struct HistoryItem {
+struct HistoryItem: Identifiable {
+//    var id: ObjectIdentifier
+    var id: UUID
     enum MessageType {
         case question, answer
     }
-    
     let text: String
     let type: MessageType
 }
 
+//(Test용)
 struct TKHistoryView: View {
     @ObservedObject var appViewStore: AppViewStore
-    
+   
     var body: some View {
         ScrollView {
             LazyVStack(spacing: 12) {
-                ForEach(appViewStore.historyItems, id: \.text) { item in
-                    if item.type == .question {
-                        HStack {
-                            Spacer()
-                            Text(item.text)
-                                .padding()
-                                .background(Color.gray)
-                                .foregroundColor(.white)
-                                .cornerRadius(15)
-                        }
-                    } else {
-                        HStack {
-                            Text(item.text)
-                                .padding()
-                                .background(Color.gray)
-                                .foregroundColor(.white)
-                                .cornerRadius(15)
-                            Spacer()
+                ForEach(appViewStore.historyItems, id: \.id) { item in
+                    if !item.text.isEmpty {
+                        if item.type == .question {
+                            HStack {
+                                Spacer()
+                                Text(item.text)
+                                    .padding()
+                                    .background(Color.gray)
+                                    .foregroundColor(.white)
+                                    .cornerRadius(15)
+                            }
+                        } else {
+                            HStack {
+                                Text(item.text)
+                                    .padding()
+                                    .background(Color.gray)
+                                    .foregroundColor(.white)
+                                    .cornerRadius(15)
+                                Spacer()
+                            }
                         }
                     }
                 }
@@ -49,6 +53,7 @@ struct TKHistoryView: View {
     }
 }
 
+
 struct TKHistoryView_Previews: PreviewProvider {
     static var previews: some View {
         let previewStore = AppViewStore(
@@ -57,10 +62,10 @@ struct TKHistoryView_Previews: PreviewProvider {
             currentAuthStatus: .authCompleted
         )
         previewStore.historyItems = [
-            HistoryItem(text: "잠이 옵니다", type: .question),
-            HistoryItem(text: "그럴 수 있어요", type: .answer),
-            HistoryItem(text: "아이스아메리카노 있나요?", type: .question),
-            HistoryItem(text: "테스트 해보시겠어요", type: .answer),
+            HistoryItem(id: UUID(), text: "잠이 옵니다", type: .question),
+            HistoryItem(id: UUID(), text: "그럴 수 있어요", type: .answer),
+            HistoryItem(id: UUID(), text: "아이스아메리카노 있나요?", type: .question),
+            HistoryItem(id: UUID(), text: "테스트 해보시겠어요", type: .answer),
         ]
         
         return TKHistoryView(appViewStore: previewStore)

--- a/talklat/talklat/Sources/Views/TKHistoryView.swift
+++ b/talklat/talklat/Sources/Views/TKHistoryView.swift
@@ -1,0 +1,68 @@
+//
+//  TKHistoryView.swift
+//  talklat
+//
+//  Created by 신정연 on 2023/10/16.
+//
+
+import SwiftUI
+
+struct HistoryItem {
+    enum MessageType {
+        case question, answer
+    }
+    
+    let text: String
+    let type: MessageType
+}
+
+struct TKHistoryView: View {
+    @ObservedObject var appViewStore: AppViewStore
+    
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                ForEach(appViewStore.historyItems, id: \.text) { item in
+                    if item.type == .question {
+                        HStack {
+                            Spacer()
+                            Text(item.text)
+                                .padding()
+                                .background(Color.gray)
+                                .foregroundColor(.white)
+                                .cornerRadius(15)
+                        }
+                    } else {
+                        HStack {
+                            Text(item.text)
+                                .padding()
+                                .background(Color.gray)
+                                .foregroundColor(.white)
+                                .cornerRadius(15)
+                            Spacer()
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal)
+        }
+    }
+}
+
+struct TKHistoryView_Previews: PreviewProvider {
+    static var previews: some View {
+        let previewStore = AppViewStore(
+            communicationStatus: .writing,
+            questionText: "",
+            currentAuthStatus: .authCompleted
+        )
+        previewStore.historyItems = [
+            HistoryItem(text: "잠이 옵니다", type: .question),
+            HistoryItem(text: "그럴 수 있어요", type: .answer),
+            HistoryItem(text: "아이스아메리카노 있나요?", type: .question),
+            HistoryItem(text: "테스트 해보시겠어요", type: .answer),
+        ]
+        
+        return TKHistoryView(appViewStore: previewStore)
+    }
+}

--- a/talklat/talklat/Sources/Views/TKIntroView.swift
+++ b/talklat/talklat/Sources/Views/TKIntroView.swift
@@ -14,12 +14,12 @@ struct TKIntroView: View {
     @ObservedObject var appViewStore: AppViewStore
     
     var body: some View {
-        Group {            
+        Group {
             switch appViewStore.communicationStatus {
             case .writing:
                 TKWritingView(appViewStore: appViewStore)
                     .transition(.opacity)
-                
+
             case .recording:
                 TKRecordingView(appViewStore: appViewStore)
                     .transition(.opacity)

--- a/talklat/talklat/Sources/Views/TKRecordingView.swift
+++ b/talklat/talklat/Sources/Views/TKRecordingView.swift
@@ -76,10 +76,7 @@ struct TKRecordingView: View {
         }
         .onDisappear {
             // TKHistoryView로 transcript 전달
-            if let answeredText = appViewStore.answeredText, !answeredText.isEmpty && !speechRecognizeManager.transcript.isEmpty {
-                let answerItem = HistoryItem(id: UUID(), text: answeredText, type: .answer)
-                appViewStore.historyItems.append(answerItem)
-            }
+            appViewStore.onRecordingViewDisappear(transcript: speechRecognizeManager.transcript)
         }
     }
     

--- a/talklat/talklat/Sources/Views/TKRecordingView.swift
+++ b/talklat/talklat/Sources/Views/TKRecordingView.swift
@@ -76,18 +76,11 @@ struct TKRecordingView: View {
         }
         .onDisappear {
             // TKHistoryView로 transcript 전달
-            if let answeredText = appViewStore.answeredText, !answeredText.isEmpty {
+            if let answeredText = appViewStore.answeredText, !answeredText.isEmpty && !speechRecognizeManager.transcript.isEmpty {
                 let answerItem = HistoryItem(id: UUID(), text: answeredText, type: .answer)
                 appViewStore.historyItems.append(answerItem)
             }
         }
-//        .onDisappear{
-//            // TKHistoryView로 transcript 전달
-//            if !(appViewStore.answeredText?.isEmpty ?? true) {
-//                let answerItem = HistoryItem(text: appViewStore.answeredText ?? "", type: .answer)
-//                appViewStore.historyItems.append(answerItem)
-//            }
-//        }
     }
     
     private func guideMessageBuilder() -> some View {

--- a/talklat/talklat/Sources/Views/TKRecordingView.swift
+++ b/talklat/talklat/Sources/Views/TKRecordingView.swift
@@ -11,7 +11,8 @@ import SwiftUI
 struct TKRecordingView: View {
     @StateObject var speechRecognizeManager: SpeechRecognizer = SpeechRecognizer()
     @ObservedObject var appViewStore: AppViewStore
-    
+    @State var historyItems: [HistoryItem] = []
+
     var body: some View {
         VStack {
             VStack {
@@ -68,8 +69,25 @@ struct TKRecordingView: View {
             }
         }
         .onChange(of: speechRecognizeManager.transcript) { transcript in
-            appViewStore.answeredTextSetter(transcript)
+            if !transcript.isEmpty {
+                appViewStore.answeredTextSetter(transcript)
+                print(transcript)
+            }
         }
+        .onDisappear {
+            // TKHistoryView로 transcript 전달
+            if let answeredText = appViewStore.answeredText, !answeredText.isEmpty {
+                let answerItem = HistoryItem(id: UUID(), text: answeredText, type: .answer)
+                appViewStore.historyItems.append(answerItem)
+            }
+        }
+//        .onDisappear{
+//            // TKHistoryView로 transcript 전달
+//            if !(appViewStore.answeredText?.isEmpty ?? true) {
+//                let answerItem = HistoryItem(text: appViewStore.answeredText ?? "", type: .answer)
+//                appViewStore.historyItems.append(answerItem)
+//            }
+//        }
     }
     
     private func guideMessageBuilder() -> some View {
@@ -100,6 +118,8 @@ struct TKRecordingView: View {
 }
 
 struct TKRecordingView_Previews: PreviewProvider {
+    @State static var showHistoryView: Bool = false
+    
     static var previews: some View {
         TKRecordingView(
             appViewStore: AppViewStore.makePreviewStore { instance in

--- a/talklat/talklat/Sources/Views/TKWritingView.swift
+++ b/talklat/talklat/Sources/Views/TKWritingView.swift
@@ -75,12 +75,6 @@ struct TKWritingView: View {
                 Spacer()
                 
                 Button {
-                    // TKHistoryView로 user's text 전달
-                    if !appViewStore.questionText.isEmpty {
-                        let newHistoryItem = HistoryItem(id: UUID(), text: appViewStore.questionText, type: .question)
-                        appViewStore.historyItems.append(newHistoryItem)
-                    }
-                    print(appViewStore.questionText)
                     appViewStore.enterSpeechRecognizeButtonTapped()
                 } label: {
                     Text("**음성 인식 전환**")
@@ -97,6 +91,10 @@ struct TKWritingView: View {
                     .frame(maxHeight: 60)
             }
             .frame(maxHeight: .infinity)
+        }
+        .onDisappear {
+            // TKHistoryView로 transcript 전달
+            appViewStore.onWritingViewDisappear()
         }
     }
     

--- a/talklat/talklat/Sources/Views/TKWritingView.swift
+++ b/talklat/talklat/Sources/Views/TKWritingView.swift
@@ -17,71 +17,87 @@ struct TKWritingView: View {
     
     // MARK: - BODY
     var body: some View {
-        VStack {
-            VStack {                
-                if let answeredText = appViewStore.answeredText {
-                    Text(answeredText)
-                        .font(.headline)
-                        .bold()
-                        .frame(
-                            maxWidth: .infinity,
-                            maxHeight: 100,
-                            alignment: .leading
-                        )
-                        .padding(.top, 40)
-                        .padding(.horizontal, 24)
-                        .padding(.bottom, 80)
+        NavigationView {
+            VStack {
+                // (Test용) TKHistoryView로 이동하는 부분
+                // MARK: 추후에 스크롤뷰리더로 화면 이동
+                NavigationLink(destination: TKHistoryView(appViewStore: appViewStore)) {
+                    Text("History")
+                        .foregroundColor(.blue)
                 }
+                .padding()
                 
-                HStack {
-                    Button {
-                        appViewStore.removeQuestionTextButtonTapped()
-                    } label: {
-                        Text("전체 지우기")
-                            .foregroundColor(.gray)
+                VStack {
+                    if let answeredText = appViewStore.answeredText {
+                        Text(answeredText)
+                            .font(.headline)
+                            .bold()
+                            .frame(
+                                maxWidth: .infinity,
+                                maxHeight: 100,
+                                alignment: .leading
+                            )
+                            .padding(.top, 40)
+                            .padding(.horizontal, 24)
+                            .padding(.bottom, 80)
                     }
-                    .font(.headline)
-                    .padding(.leading, 24)
-                    .padding(.top, 20)
-                    .padding(.bottom, 36)
-                    .disabled(appViewStore.questionText.isEmpty)
                     
-                    Spacer()
-                }
-                .opacity(focusState ? 1.0 : 0.0)
-                .animation(.easeInOut, value: focusState)
-                
-                // MARK: Multiline Placeholder 구현 불가
-                // lofi: 한 줄만 보이는 placeholderㅠㅠ
-                TKTextField(appViewStore: appViewStore)
-                    .focused($focusState)
-                    .overlay(alignment: .topLeading) {
-                        characterLimitView()
-                            .padding(.leading, 24)
-                            .opacity(focusState ? 1.0 : 0.0)
-                            .animation(.easeInOut, value: focusState)
+                    HStack {
+                        Button {
+                            appViewStore.removeQuestionTextButtonTapped()
+                        } label: {
+                            Text("전체 지우기")
+                                .foregroundColor(.gray)
+                        }
+                        .font(.headline)
+                        .padding(.leading, 24)
+                        .padding(.top, 20)
+                        .padding(.bottom, 36)
+                        .disabled(appViewStore.questionText.isEmpty)
+                        
+                        Spacer()
                     }
+                    .opacity(focusState ? 1.0 : 0.0)
+                    .animation(.easeInOut, value: focusState)
+                    
+                    // MARK: Multiline Placeholder 구현 불가
+                    // TODO: TLTextField 코드로 교체
+                    TKTextField(appViewStore: appViewStore)
+                        .focused($focusState)
+                        .overlay(alignment: .topLeading) {
+                            characterLimitView()
+                                .padding(.leading, 24)
+                                .opacity(focusState ? 1.0 : 0.0)
+                                .animation(.easeInOut, value: focusState)
+                        }
+                }
+                
+                Spacer()
+                
+                Button {
+                    // TKHistoryView로 user's text 전달
+                    if !appViewStore.questionText.isEmpty {
+                        let newHistoryItem = HistoryItem(id: UUID(), text: appViewStore.questionText, type: .question)
+                        appViewStore.historyItems.append(newHistoryItem)
+                    }
+                    print(appViewStore.questionText)
+                    appViewStore.enterSpeechRecognizeButtonTapped()
+                } label: {
+                    Text("**음성 인식 전환**")
+                        .foregroundColor(.white)
+                }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 16)
+                .background {
+                    Capsule()
+                        .foregroundColor(.gray)
+                }
+                
+                Spacer()
+                    .frame(maxHeight: 60)
             }
-            
-            Spacer()
-            
-            Button {
-                appViewStore.enterSpeechRecognizeButtonTapped()
-            } label: {
-                Text("**음성 인식 전환**")
-                    .foregroundColor(.white)
-            }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 16)
-            .background {
-                Capsule()
-                    .foregroundColor(.gray)
-            }
-            
-            Spacer()
-                .frame(maxHeight: 60)
+            .frame(maxHeight: .infinity)
         }
-        .frame(maxHeight: .infinity)
     }
     
     // MARK: - METHODS

--- a/talklat/talklat/Sources/Views/TKWritingView.swift
+++ b/talklat/talklat/Sources/Views/TKWritingView.swift
@@ -21,7 +21,7 @@ struct TKWritingView: View {
             VStack {
                 // (Test용) TKHistoryView로 이동하는 부분
                 // MARK: 추후에 스크롤뷰리더로 화면 이동
-                NavigationLink(destination: TKHistoryView(appViewStore: appViewStore)) {
+                NavigationLink(destination: TestHistoryView(appViewStore: appViewStore)) {
                     Text("History")
                         .foregroundColor(.blue)
                 }

--- a/talklat/talklat/Sources/Views/TestHistoryView.swift
+++ b/talklat/talklat/Sources/Views/TestHistoryView.swift
@@ -18,7 +18,7 @@ struct HistoryItem: Identifiable {
 }
 
 //(Test용)
-struct TKHistoryView: View {
+struct TestHistoryView: View {
     @ObservedObject var appViewStore: AppViewStore
    
     var body: some View {
@@ -68,6 +68,6 @@ struct TKHistoryView_Previews: PreviewProvider {
             HistoryItem(id: UUID(), text: "테스트 해보시겠어요", type: .answer),
         ]
         
-        return TKHistoryView(appViewStore: previewStore)
+        return TestHistoryView(appViewStore: previewStore)
     }
 }

--- a/talklat/talklat/Sources/Views/TestHistoryView.swift
+++ b/talklat/talklat/Sources/Views/TestHistoryView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct HistoryItem: Identifiable {
-//    var id: ObjectIdentifier
     var id: UUID
     enum MessageType {
         case question, answer
@@ -52,7 +51,6 @@ struct TestHistoryView: View {
         }
     }
 }
-
 
 struct TKHistoryView_Previews: PreviewProvider {
     static var previews: some View {


### PR DESCRIPTION
### 📝 작업 목적
| ⚒️ Title | `HistoryView와 대화 내용 띄우기` | 
| :--- | :--- |
| 📜 **Description** | 진행중인 대화 히스토리(저장없이 뷰에 띄우기) |
| ![](https://img.shields.io/badge/-black?logo=figma)**Figma** | [Link](<!-- URL -->) |
| ![](https://img.shields.io/badge/-black?logo=notion)**Notion Card** | [Link](<!-- URL -->) |

### 🛠️ Tasks

* [x] TKHistoryView에 WritingView, RecordingView의 대화 내용을 띄웁니다.
우선은 저장소 따로 없이, 현재 대화하는 내용만 해당됩니다.

---

## 작업 사항
<!-- 1. TKHistoryView에 들어갈 TestHistoryView -->
1. History 구조체
- id: 각 텍스트를 뷰에 띄울 때의 기준이 됩니다.
- text: 내용
- type: 유형(question: 유저(청각장애인), answer: 상대방(청인))

- HistoryView는 **임의로** TKWritingView에 네비게이션으로 연결해놓았습니다.

2. TKWritingView
- "음성 인식 전환" 버튼 클릭 시(==화면 전환 포인트) 텍스트가 히스토리아이템(question type)에 저장됩니다.
```swift
if !appViewStore.questionText.isEmpty {
                        let newHistoryItem = HistoryItem(id: UUID(), text: appViewStore.questionText, type: .question)
                        appViewStore.historyItems.append(newHistoryItem)
                    }
```
3. TKRecordingView
화면 .onDisappesr을 기준으로 transcript에 저장되어있던 text를 히스토리아이템(answer type)에 저장됩니다.
```swift
.onDisappear {
            // TKHistoryView로 transcript 전달
            if let answeredText = appViewStore.answeredText, !answeredText.isEmpty {
                let answerItem = HistoryItem(id: UUID(), text: answeredText, type: .answer)
                appViewStore.historyItems.append(answerItem)
            }
        }
```
4. 음성인식 시 빈 transcript가 들어올 때의 문제점이 있었습니다.
1) 빈 transcript 만큼 히스토리뷰에도 빈 공백이 생겼었는데, 히스토리뷰의 ForEach문 기준에 부여한 historyItem의 id로 하니 해결했습니다.
2) 1번을 해결하니, 첫번째로 음성인식 때 빈 transcript가 들어올 때를 제외하고, 대화 중간에 빌 때에는 이전 음성인식 대화가 저장되어서, TKRecordingView에서 transcript를 저장하는 부분을 수정해서 해결했습니다. -> PR 이후 푸쉬했어요!

---

## 작업 결과
<table>
<tr>
<td>

![IMG_0514](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/88757043/baca6865-729b-471d-9cdd-a5760706e385)

</td>
<td>

![IMG_0517](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/88757043/aa3fdd7d-461a-423a-b457-6c12f853399c)

</td>
<td>

![IMG_0518](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/88757043/71feea73-b7bf-4bff-9877-c7f742fa6464)

</td>
</tr>
</table>


---

#### 기타 공유사항

- 계속해서 히스토리뷰 말풍선들 사이에 공백이 생기던 이슈를 리앤이 해결해주셨습니다..히스토리뷰에서 foreach로 historyItem 불러오는 부분의 기준을 id가 아니라 text로 해서 발생하는 문제였어요,,
"남의 눈으로 봐야 돼"하며 겸손까지 갖춘 리앤을 공식적으로 칭찬해요..

TODO
- 음성인식에서 말을 안하는 경우(대답 텍스트 transcript가 없는 경우)에는 다음 TKWritingView에 원래 이전 대답이 보이는데, 이 부분도 같이 비워놓을지, 아니면 그래도 이전 텍스트를 보일지 논의해봐야겠어요!
우선 히스토리뷰에는 빈 transcript는 무시하고 나머지만 뷰에 띄웁니다.
- 앞으로 수정될 TKWritingView -> TextField 디자인시스템 반영해서 HistoryItem에 저장하는 부분을 다시 작업합니다.
- TestHistoryView는 내비게이션으로 구현해놓았는데, 리앤이 이어서 작업하실 때에는 ForEach 이하 부분만 참고하시면 될 것 같습니다 <3

