### PR TITLE
Feat/#38 color design system 구현

### DIFF
--- a/talklat/talklat.xcodeproj/project.pbxproj
+++ b/talklat/talklat.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		57E76EB72ACEC91A00D79553 /* StaffSpeechView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E76EB62ACEC91A00D79553 /* StaffSpeechView.swift */; };
+		7E8445DA2ADFB4FC00CFB8BC /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8445D92ADFB4FC00CFB8BC /* Color+Hex.swift */; };
+		7E8445DE2ADFBBD900CFB8BC /* TKColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8445DD2ADFBBD900CFB8BC /* TKColor.swift */; };
 		7E8906412ACEA31500C9947A /* TKIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8906402ACEA31500C9947A /* TKIntroView.swift */; };
 		7E8D17D62ACE8AED00E904E5 /* talklatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17D52ACE8AED00E904E5 /* talklatTests.swift */; };
 		7E8D17E02ACE8AED00E904E5 /* talklatUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17DF2ACE8AED00E904E5 /* talklatUITests.swift */; };
@@ -48,6 +50,8 @@
 
 /* Begin PBXFileReference section */
 		57E76EB62ACEC91A00D79553 /* StaffSpeechView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaffSpeechView.swift; sourceTree = "<group>"; };
+		7E8445D92ADFB4FC00CFB8BC /* Color+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Hex.swift"; sourceTree = "<group>"; };
+		7E8445DD2ADFBBD900CFB8BC /* TKColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKColor.swift; sourceTree = "<group>"; };
 		7E8906402ACEA31500C9947A /* TKIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKIntroView.swift; sourceTree = "<group>"; };
 		7E8D17C12ACE8AEC00E904E5 /* talklat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = talklat.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E8D17C42ACE8AEC00E904E5 /* talklatApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = talklatApp.swift; sourceTree = "<group>"; };
@@ -208,6 +212,7 @@
 			isa = PBXGroup;
 			children = (
 				7EF737962AD43EE000FCBA21 /* TKTextField.swift */,
+				7E8445DD2ADFBBD900CFB8BC /* TKColor.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -216,6 +221,7 @@
 			isa = PBXGroup;
 			children = (
 				7EFA2C2A2AD51FC80013B533 /* Double+Degree.swift */,
+				7E8445D92ADFB4FC00CFB8BC /* Color+Hex.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -368,7 +374,9 @@
 				7EF737942AD3DE5600FCBA21 /* Constants.swift in Sources */,
 				7EF7378C2AD3C87700FCBA21 /* AppViewStore.swift in Sources */,
 				7EFA2C2B2AD51FC80013B533 /* Double+Degree.swift in Sources */,
+				7E8445DE2ADFBBD900CFB8BC /* TKColor.swift in Sources */,
 				7EF737972AD43EE000FCBA21 /* TKTextField.swift in Sources */,
+				7E8445DA2ADFB4FC00CFB8BC /* Color+Hex.swift in Sources */,
 				EF67C6532AD13BF700C1074E /* AppRootManager.swift in Sources */,
 				57E76EB72ACEC91A00D79553 /* StaffSpeechView.swift in Sources */,
 				7EE087E82ADD4FAE00E07720 /* TKHistoryView.swift in Sources */,

--- a/talklat/talklat/Sources/Utilities/Extensions/Color+Hex.swift
+++ b/talklat/talklat/Sources/Utilities/Extensions/Color+Hex.swift
@@ -5,4 +5,27 @@
 //  Created by Celan on 2023/10/18.
 //
 
-import Foundation
+import SwiftUI
+
+extension Color {
+    init(hex: Int, opacity: Double = 1.0) {
+        let red = Double((hex >> 16) & 0xff) / 255
+        let green = Double((hex >> 8) & 0xff) / 255
+        let blue = Double((hex >> 0) & 0xff) / 255
+        
+        self.init(.sRGB, red: red, green: green, blue: blue, opacity: opacity)
+    }
+    
+    init(hex: String) {
+        let scanner = Scanner(string: hex)
+        _ = scanner.scanString("#")
+        
+        var rgb: UInt64 = 0
+        scanner.scanHexInt64(&rgb)
+        
+        let r = Double((rgb >> 16) & 0xFF) / 255.0
+        let g = Double((rgb >>  8) & 0xFF) / 255.0
+        let b = Double((rgb >>  0) & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
+}

--- a/talklat/talklat/Sources/Utilities/Extensions/Color+Hex.swift
+++ b/talklat/talklat/Sources/Utilities/Extensions/Color+Hex.swift
@@ -1,0 +1,8 @@
+//
+//  Color+Hex.swift
+//  talklat
+//
+//  Created by Celan on 2023/10/18.
+//
+
+import Foundation

--- a/talklat/talklat/Sources/Views/Components/TKColor.swift
+++ b/talklat/talklat/Sources/Views/Components/TKColor.swift
@@ -1,0 +1,20 @@
+//
+//  TKColor.swift
+//  talklat
+//
+//  Created by Celan on 2023/10/18.
+//
+
+import SwiftUI
+
+struct TKColor: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct TKColor_Previews: PreviewProvider {
+    static var previews: some View {
+        TKColor()
+    }
+}

--- a/talklat/talklat/Sources/Views/Components/TKColor.swift
+++ b/talklat/talklat/Sources/Views/Components/TKColor.swift
@@ -7,14 +7,157 @@
 
 import SwiftUI
 
-struct TKColor: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+extension Color {
+    static var colorScheme = UITraitCollection.current.userInterfaceStyle
+
+    static var gray100: Color {
+        get {
+            switch colorScheme {
+            case .light:
+                return Color(hex: "#F7F7FA")
+            case .dark:
+                return Color(hex: "#1C1D27")
+            case .unspecified:
+                return Color.gray
+            @unknown default:
+                return Color.gray
+            }
+        }
+    }
+    
+    static var gray200: Color {
+        get {
+            switch colorScheme {
+            case .light:
+                return Color(hex: "#EBEBF3")
+            case .dark:
+                return Color(hex: "#323340")
+            case .unspecified:
+                return Color.gray
+            @unknown default:
+                return Color.gray
+            }
+        }
+    }
+    
+    static var gray300: Color {
+        get {
+            switch colorScheme {
+            case .light:
+                return Color(hex: "#D6D6E1")
+            case .dark:
+                return Color(hex: "#4B4E5B")
+            case .unspecified:
+                return Color.gray
+            @unknown default:
+                return Color.gray
+            }
+        }
+    }
+    
+    static var gray400: Color {
+        get {
+            switch colorScheme {
+            case .light:
+                return Color(hex: "#B1B2BE")
+            case .dark:
+                return Color(hex: "#676A77")
+            case .unspecified:
+                return Color.gray
+            @unknown default:
+                return Color.gray
+            }
+        }
+    }
+    
+    static var gray500: Color {
+        get { Color(hex: "#868896") }
+    }
+    
+    static var gray600: Color {
+        get {
+            switch colorScheme {
+            case .light:
+                return Color(hex: "#676A77")
+            case .dark:
+                return Color(hex: "#B1B2BE")
+            case .unspecified:
+                return Color.gray
+            @unknown default:
+                return Color.gray
+            }
+        }
+    }
+    
+    static var gray700: Color {
+        get {
+            switch colorScheme {
+            case .light:
+                return Color(hex: "#4B4E5B")
+            case .dark:
+                return Color(hex: "#D6D6E1")
+            case .unspecified:
+                return Color.gray
+            @unknown default:
+                return Color.gray
+            }
+        }
+    }
+    
+    static var gray800: Color {
+        get {
+            switch colorScheme {
+            case .light:
+                return Color(hex: "#393B49")
+            case .dark:
+                return Color(hex: "#EBEBF3")
+            case .unspecified:
+                return Color.gray
+            @unknown default:
+                return Color.gray
+            }
+        }
+    }
+    
+    static var gray900: Color {
+        get {
+            switch colorScheme {
+            case .light:
+                return Color(hex: "#222331")
+            case .dark:
+                return Color(hex: "#F7F7FA")
+            case .unspecified:
+                return Color.gray
+            @unknown default:
+                return Color.gray
+            }
+        }
     }
 }
 
-struct TKColor_Previews: PreviewProvider {
+struct ColorTestView: PreviewProvider {
     static var previews: some View {
-        TKColor()
+        VStack {
+            Color.gray100
+                .overlay { Text("Color Gray 100") }
+            Color.gray200
+                .overlay { Text("Color Gray 200") }
+            Color.gray300
+                .overlay { Text("Color Gray 300") }
+            Color.gray400
+                .overlay { Text("Color Gray 400") }
+            Color.gray500
+                .overlay { Text("Color Gray 500") }
+            Color.gray600
+                .overlay { Text("Color Gray 600") }
+            Color.gray700
+                .overlay { Text("Color Gray 700") }
+            Color.gray800
+                .overlay { Text("Color Gray 800") }
+            Color.gray900
+                .overlay { Text("Color Gray 900") }
+        }
+        .ignoresSafeArea(edges: .bottom)
+        .background { Color.red }
     }
 }

--- a/talklat/talklat/Sources/Views/TKHistoryView.swift
+++ b/talklat/talklat/Sources/Views/TKHistoryView.swift
@@ -53,7 +53,7 @@ struct TKHistoryView: View {
                 }
             }
             .padding(.top, 16)
-            .background { Color(.systemGray6 )}
+            .background { Color(.systemGray6) }
             
             VStack {
                 VStack(spacing: 12) {

--- a/talklat/talklat/Sources/Views/TKIntroView.swift
+++ b/talklat/talklat/Sources/Views/TKIntroView.swift
@@ -10,6 +10,8 @@
 import SwiftUI
 
 struct TKIntroView: View {
+    @Environment(\.scenePhase)
+    var scenePhase
     @StateObject var gyroMotionStore: GyroScopeStore = GyroScopeStore()
     @ObservedObject var appViewStore: AppViewStore
     
@@ -39,6 +41,9 @@ struct TKIntroView: View {
                 }
                 HapticManager.sharedInstance.generateHaptic(.success)
             }
+        }
+        .onChange(of: scenePhase) { _ in
+            Color.colorScheme = UITraitCollection.current.userInterfaceStyle
         }
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->
<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `color design system 구현` | 
| :--- | :--- |
| 📜 **Description** | color design system의 그레이 톤을 우선 구현합니다. |
| 📌 **Issue Number** | #38 |
| ![](https://img.shields.io/badge/-black?logo=figma)**Figma** | [Link](https://www.figma.com/file/Mb450yYTvio6Q9y6d0otwv/%F0%9F%8D%8EALLWAY-Team?type=design&node-id=1113-2943&mode=design) |
| ![](https://img.shields.io/badge/-black?logo=notion)**Notion Card** | _ |

---

## 작업 사항
<!-- 1. MainIntroView의 ScrollView 구현 -->
1. Color Design System을 구현하기 위한 `init(hex:)` 준비
2. 유저의 `ColorScheme`을 받아서 라이트모드와 다크모드 대응
3. ScenePhase가 변경되면서 모드의 전환이 일어날 때도 모드 대응

### `Logics`
```swift
extension Color {
  static var colorScheme = UITraitCollection.current.userInterfaceStyle
  
  static var gray100: Color {
    get {
      // ColorScheme에 따라 적합한 컬러를 리턴
      switch colorScheme {
      case .light:
        return Color(hex: "#F7F7FA")
      case .dark:
        return Color(hex: "#1C1D27")
      // 기타 케이스에서는 SwiftUI의 기본 Gray 컬러를 리턴
      case .unspecified:
        return Color.gray
      @unknown default:
        return Color.gray
      }
    }
  }
}
```

---

## 작업 결과
| 라이트모드 | 다크모드 |
| --- | --- |
| ![simulator_screenshot_596D4DD2-2052-4D06-A876-0595DED77E0F](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/adb7be8f-bd1f-4f28-ac93-b266dbe9e035) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-10-19 at 10 28 36](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/386f3ee7-2aa1-49f9-8df4-811578304833) |
---

#### 기타 공유사항
<!-- 야기될 수 있는 사이드 이펙트, 조사가 필요한 내용 등을 작성합니다. --> 
1. 추후 Gray가 사용되고 있는 모든 컬러에 대한 변화가 예정되어 있습니다.
2. Gray 이외의 색상이 추가되면 추가 작업을 진행할 예정입니다.