### PR TITLE
Feat/#42 TKHistoryView와 HistoryItems 연동

### DIFF
--- a/talklat/talklat/Sources/Views/TKHistoryView.swift
+++ b/talklat/talklat/Sources/Views/TKHistoryView.swift
@@ -8,53 +8,65 @@
 import SwiftUI
 
 struct TKHistoryView: View {
+    @Environment(\.colorScheme)
+    var colorScheme
     @ObservedObject var appViewStore: AppViewStore
     
     var body: some View {
-        ZStack {
-            ScrollView {
-                // TODO: - ForEach의 data 아규먼트 수정
-                // TODO: - 각 Color 값을 디자인 시스템 값으로 추후 수정
-                ForEach(0..<100) { int in
-                    if int % 2 == 0 {
-                        VStack(alignment: .leading) {
-                            Image(systemName: "waveform.circle.fill")
-                                .resizable()
-                                .frame(width: 24, height: 24)
-                                .foregroundColor(Color(.systemGray))
-                                .padding(.leading, 4)
-                            
-                            Text("일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠")
-                                .font(.headline)
-                                .padding(.horizontal, 16)
-                                .padding(.vertical, 8)
-                                .background {
-                                    RoundedRectangle(cornerRadius: 12)
-                                        .fill(Color(.white))
-                                        .frame(maxHeight: 100)
-                                }
+        ScrollView {
+            // TODO: - ForEach의 data 아규먼트 수정
+            // TODO: - 각 Color 값을 디자인 시스템 값으로 추후 수정
+            ForEach(
+                appViewStore.historyItems,
+                id: \.id
+            ) { item in
+                switch item.type {
+                case .question:
+                    Text(item.text)
+                        .font(.subheadline)
+                        .foregroundColor(.gray700)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background {
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Color.gray200)
                         }
-                        .padding(.horizontal, 24)
+                        .frame(
+                            maxWidth: .infinity,
+                            alignment: .trailing
+                        )
+                        .padding(.trailing, 24)
+                        .padding(.leading, 68)
+                        .padding(.top, 32)
+                    
+                case .answer:
+                    VStack(alignment: .leading) {
+                        Image(systemName: "waveform.circle.fill")
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(Color.gray700)
+                            .padding(.leading, 4)
                         
-                    } else {
-                        Text("일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠")
-                            .font(.subheadline)
+                        Text(item.text)
+                            .font(.headline)
+                            .foregroundColor(.gray700)
                             .padding(.horizontal, 16)
                             .padding(.vertical, 8)
                             .background {
                                 RoundedRectangle(cornerRadius: 12)
-                                    .fill(Color(.systemGray4))
-                                    .frame(maxHeight: 100)
+                                    .fill(Color(.white))
                             }
-                            .padding(.trailing, 24)
-                            .padding(.leading, 68)
-                            .padding(.top, 32)
                     }
+                    .frame(
+                        maxWidth: .infinity,
+                        alignment: .leading
+                    )
+                    .padding(.horizontal, 24)
                 }
             }
-            .padding(.top, 16)
-            .background { Color(.systemGray6) }
-            
+        }
+        .padding(.top, 16)
+        .safeAreaInset(edge: .bottom) {
             VStack {
                 VStack(spacing: 12) {
                     Text("텍스트 작성 페이지로 돌아가기")
@@ -67,28 +79,29 @@ struct TKHistoryView: View {
                         .frame(width: 32, height: 10)
                         .padding(.bottom, 10)
                 }
-                    .frame(
-                        maxWidth: .infinity,
-                        maxHeight: 100,
-                        alignment: .top
-                    )
-                    .foregroundColor(Color(.systemGray))
-                    .background {
-                        Rectangle()
-                            .fill(Color.white)
-                            .shadow(
-                                color: Color(.systemGray4),
-                                radius: 30,
-                                y: -1
-                            )
-                    }
+                .frame(
+                    maxWidth: .infinity,
+                    maxHeight: 100,
+                    alignment: .top
+                )
+                .foregroundColor(Color.gray500)
+                .background {
+                    Rectangle()
+                        .fill(
+                            colorScheme == .light
+                            ? Color.white
+                            : Color.black
+                        )
+                        .shadow(
+                            color: Color.gray300,
+                            radius: 25,
+                            y: -1
+                        )
+                }
             }
-            .frame(
-                maxHeight: .infinity,
-                alignment: .bottom
-            )
         }
         .ignoresSafeArea(edges: .bottom)
+        .background { Color.gray100 }
         .navigationTitle("히스토리")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(
@@ -106,6 +119,12 @@ struct TKHistoryView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
             TKHistoryView(appViewStore: .makePreviewStore(condition: { store in
+                store.historyItems.append(.init(id: .init(), text: "대답1", type: .answer))
+                store.historyItems.append(.init(id: .init(), text: "질문1", type: .question))
+                store.historyItems.append(.init(id: .init(), text: "일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구1", type: .answer))
+                store.historyItems.append(.init(id: .init(), text: "일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구1", type: .question))
+                store.historyItems.append(.init(id: .init(), text: "일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구1", type: .answer))
+                store.historyItems.append(.init(id: .init(), text: "일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구일이삼사오육칠팔구1", type: .question))
                 
             }))
         }

--- a/talklat/talklat/Sources/Views/TKWritingView.swift
+++ b/talklat/talklat/Sources/Views/TKWritingView.swift
@@ -21,7 +21,9 @@ struct TKWritingView: View {
             VStack {
                 // (Test용) TKHistoryView로 이동하는 부분
                 // MARK: 추후에 스크롤뷰리더로 화면 이동
-                NavigationLink(destination: TestHistoryView(appViewStore: appViewStore)) {
+                NavigationLink {
+                  TKHistoryView(appViewStore: appViewStore)
+                } label: {
                     Text("History")
                         .foregroundColor(.blue)
                 }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->
<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `TKHistoryView와 HistoryItems 연동` | 
| :--- | :--- |
| 📜 **Description** | TKHistoryView와 HistoryItems를 연동하고 디자인 시스템의 그레이 컬러를 적용합니다 |
| 📌 **Issue Number** | #42 |
| ![](https://img.shields.io/badge/-black?logo=figma)**Figma** | [Link](<!-- URL -->) |
| ![](https://img.shields.io/badge/-black?logo=notion)**Notion Card** | _ |

---

## 작업 사항
1. TKHistoryView를 appViewStore.HistoryItems와 연동
2. Gray Color를 적용함!

### `Logics`
- UI 쪽의 로직이 간단해서 생략합니다! 
- Lofi 단계에 대응하기 위해 `Button`으로만 적용합니다.

---

## 작업 결과
<!-- 이미지, gif 등을 캡쳐하여 첨부합니다. -->
<!-- 해당 섹션은 필수가 아닙니다! -->
| 시뮬레이터 작동화면 | 프리뷰의 목업 화면|
| --- | --- |
| ![simulator_screenshot_C2EF43D7-6487-4DC2-8E40-493B2FABF77C](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/745777db-3778-4899-b02f-75786c3c6c2f) | ![simulator_screenshot_C2EF43D7-6487-4DC2-8E40-493B2FABF77C](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/2bcb0cf2-413e-4d74-b38c-2615bfc9b75f") |

---

#### 기타 공유사항
<!-- 야기될 수 있는 사이드 이펙트, 조사가 필요한 내용 등을 작성합니다. --> 
1. 스크롤 트랜지션에 따라 자유롭게 변경해주세요!
  - cc. @lianne-b 
