### PR TITLE
[Feat/#49] TLTextField에서 글자수 제거, TKWritingView에 overlay

### DIFF
--- a/talklat/talklat/Sources/Stores/AppViewStore.swift
+++ b/talklat/talklat/Sources/Stores/AppViewStore.swift
@@ -26,7 +26,7 @@ final class AppViewStore: ObservableObject {
     @Published public var messageOffset: CGSize = .zero
     @Published public var isMessageTapped: Bool = false
     
-    public let questionTextLimit: Int = 55
+    public let questionTextLimit: Int = 160
     
     // MARK: INIT
     init(

--- a/talklat/talklat/Sources/Views/Components/TLTextField.swift
+++ b/talklat/talklat/Sources/Views/Components/TLTextField.swift
@@ -35,7 +35,6 @@ struct TLTextField<Button: View>: View {
         case let .normal(textLimit):
             VStack {
                 leadingButtonSection
-                textCountIndicator(textLimit: textLimit)
                 inputFieldSection(textLimit: textLimit)
             }
         }
@@ -51,22 +50,6 @@ struct TLTextField<Button: View>: View {
         .padding(.bottom, 24)
     }
     
-    private func textCountIndicator(textLimit: Int) -> some View {
-        HStack {
-            Text("\($text.wrappedValue.count)/\(textLimit)")
-                .font(.system(size: 12, weight: .regular))
-                .monospacedDigit()
-                .foregroundColor(
-                    text.count >= textLimit
-                    ? .red
-                    : .gray
-                )
-                .padding(.leading, 24)
-            
-            Spacer()
-        }
-    }
-    
     private func inputFieldSection(textLimit: Int) -> some View {
         ZStack {
             TextField(
@@ -75,8 +58,8 @@ struct TLTextField<Button: View>: View {
                 axis: .vertical
             )
             .font(.system(size: 20, weight: .bold))
-            .padding(.leading, 24)
-            .padding(.trailing, 24)
+            .lineSpacing(12)
+            .padding(.horizontal, 24)
             .frame(maxWidth: .infinity)
             .autocorrectionDisabled()
             .textInputAutocapitalization(.never)

--- a/talklat/talklat/Sources/Views/TKWritingView.swift
+++ b/talklat/talklat/Sources/Views/TKWritingView.swift
@@ -59,7 +59,6 @@ struct TKWritingView: View {
                 }
                 
             }
-            
             TLTextField(
                 style: .normal(textLimit: 160),
                 text: Binding(
@@ -78,8 +77,17 @@ struct TKWritingView: View {
                                 : .gray
                             )
                     }
+                    .opacity(focusState ? 1.0 : 0.0)
                 }
             )
+            .focused($focusState)
+            .overlay(alignment: .topLeading) {
+                characterLimitView()
+                    .padding(.leading, 24)
+                    .padding(.top, 36)
+                    .opacity(focusState ? 1.0 : 0.0)
+                    .animation(.easeInOut, value: focusState)
+            }
             .padding(.top, 24)
             
             Spacer()
@@ -111,6 +119,18 @@ struct TKWritingView: View {
             appViewStore.onWritingViewDisappear()
         }
     }
+    
+    // MARK: - METHODS
+        private func characterLimitView() -> some View {
+            Text("\(appViewStore.questionText.count)/\(appViewStore.questionTextLimit)")
+                .font(.system(size: 12, weight: .regular))
+                .monospacedDigit()
+                .foregroundColor(
+                    hasQuestionTextReachedMaximumCount
+                    ? .red
+                    : .gray
+                )
+        }
 }
 
 struct TKWritingView_Previews: PreviewProvider {


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #49 -->
<!-- Figma: Link (선택) -->
<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `TLTextField에서 글자수 제거, TKWritingView에 overlay` | 
| :--- | :--- |
| 📜 **Description** | TKWritingview에서 텍스트필드를 탭하면 <전체지우기>버튼과 <글자수>가 나타나게 하기 위해 TLTextField에서 글자수 제거, TKWritingView에 글자수 overlay |
| 📌 **Issue Number** | #49  |
| ![](https://img.shields.io/badge/-black?logo=figma)**Figma** | [Link](<!-- URL -->) |
| ![](https://img.shields.io/badge/-black?logo=notion)**Notion Card** | [Link](<!-- URL -->) |

---

## 작업 사항

<table>
<tr>
<td>

피그마
![iPhone 14 Pro - 192](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/88757043/5a72f602-95cb-444e-b67d-d43624063ff3)

</td>
<td>

작업 화면1

![IMG_0531](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/88757043/694f436c-4be1-4d2a-b2cd-56cf1015526d)

</td>
<td>

작업화면2

![IMG_0530](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/88757043/9c0bf9a3-d999-4381-ad0c-dd9a1ab9734e)

</td>
</tr>
</table>

- TKWritingView에서 첫화면이 (위 사진과 같게) 수정
1) <전체지우기버튼>, <글자 수>는 textfield를 탭하면 보이게 수정했습니다.($focusState)
2) 위 작업을 하기 위해서 <글자 수>를 나타내는 부분이 기존에는 TLTextField에 합쳐져 있었는데, 
TKWritingView에서의 opacity조정을 위해서 TLTextField에서 제거하고, TKWritingView에서 characterLimitView()를 다시 살렸습니다. 

#### 기타 공유사항
