### PR TITLE
Fix/#48 fix button malfunction

### DIFF
--- a/talklat/talklat/Sources/Managers/SpeechRecognizer.swift
+++ b/talklat/talklat/Sources/Managers/SpeechRecognizer.swift
@@ -167,9 +167,10 @@ final class SpeechRecognizer: ObservableObject {
         } else {
             errorMessage += error.localizedDescription
         }
-        Task { @MainActor [errorMessage] in
-            transcript = "<< \(errorMessage) >>"
-        }
+        // MARK: Answered Text에 에러 메시지가 쌓이지 않도록 후속 작업 각주 처리
+//        Task { @MainActor _ in
+//            transcript = "<< \(errorMessage) >>"
+//        }
     }
 }
 

--- a/talklat/talklat/Sources/Views/TKWritingView.swift
+++ b/talklat/talklat/Sources/Views/TKWritingView.swift
@@ -20,11 +20,14 @@ struct TKWritingView: View {
         VStack {
             // (Test용) TKHistoryView로 이동하는 부분
             // TODO: Upper Chevron
-            
-            if let answeredText = appViewStore.answeredText {
+            if let lastItem = appViewStore.historyItems.last,
+               lastItem.type == .answer {
                 ZStack(alignment: .top) {
                     RoundedRectangle(cornerRadius: 12)
-                        .frame(width: UIScreen.main.bounds.width * 0.9, height: UIScreen.main.bounds.height * 0.2)
+                        .frame(
+                            width: UIScreen.main.bounds.width * 0.9,
+                            height: UIScreen.main.bounds.height * 0.2
+                        )
                         .foregroundStyle(.gray.opacity(0.1))
                     
                     HStack {
@@ -42,7 +45,7 @@ struct TKWritingView: View {
                         Spacer()
                     }
                     
-                    Text("        " + answeredText)
+                    Text("        " + lastItem.text)
                         .font(.headline)
                         .bold()
                         .lineSpacing(10)
@@ -57,7 +60,6 @@ struct TKWritingView: View {
                             .combined(with: .opacity)
                         )
                 }
-                
             }
             
             TLTextField(
@@ -89,16 +91,15 @@ struct TKWritingView: View {
             } label: {
                 Text("**음성 인식 전환**")
                     .foregroundColor(.white)
+                    .padding(.horizontal, 25)
+                    .padding(.vertical, 22)
+                    .background {
+                        Capsule()
+                            .foregroundColor(.gray)
+                    }
             }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 16)
-            .background {
-                Capsule()
-                    .foregroundColor(.gray)
-            }
+            .padding(.bottom, 20)
             
-            Spacer()
-                .frame(maxHeight: 60)
         }
         .onAppear {
             appViewStore.onWritingViewAppear()
@@ -116,7 +117,7 @@ struct TKWritingView: View {
 struct TKWritingView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
-            ScrollContainer(appViewStore: AppViewStore.makePreviewStore {
+            TKWritingView(appViewStore: AppViewStore.makePreviewStore {
                 instance in
                 instance.questionTextSetter("test")
                 instance.historyItems.append(.init(id: .init(), text: "dfdf", type: .answer))


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->
<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `WritingView 에서의 Button 오작동 버그 수정` | 
| :--- | :--- |
| 📜 **Description** | WritingView에서 Button이 작동되지 않는 버그와 관련된 버튼 액션 버그를 수정합니다. |
| 📌 **Issue Number** | #48 |
| ![](https://img.shields.io/badge/-black?logo=figma)**Figma** | _ |
| ![](https://img.shields.io/badge/-black?logo=notion)**Notion Card** | _ |

---

## 작업 사항
<!-- 1. MainIntroView의 ScrollView 구현 -->
1. TKWritingView의 음성 인식 전환 버튼의 오작동 수정
  - Tappable 영역 수정

2. Button에 간섭하는 `ScrollContainer`의 overlay 관련 이슈 발견
  - 관련 이슈에 대해 함께 상황 공유 후, @lianne-b 브랜치에서 해결 예정
  - cc. @lianne-b 

### `Logics`

```swift
Button {
    appViewStore.enterSpeechRecognizeButtonTapped()
} label: {
  Text("**음성 인식 전환**")
      .foregroundColor(.white)
      .padding(.horizontal, 25)
      .padding(.vertical, 22)
      .background {
        Capsule()
          .foregroundColor(.gray)
      }
}
.padding(.bottom, 20)
```

---

#### 기타 공유사항
1. `ScrollContainer`의 머지 이후, Keyboard에 의해 버튼이 가려지는 이슈를 해결합니다.
  - View의 레이어 계층이 Geometry -> IntroView 로 설정되며 발생하는 이슈로 확인
  - cc. @lianne-b 

2. `TKRecordingView`와 관련된 `ZStack` Layout 이 추후 작업에서 수정될 예정입니다.
  - cc. @MADElinessss 
