### PR TITLE
[Fix/#51] Fix gyro using area division and rotation rate

### DIFF
--- a/talklat/talklat/Sources/Stores/GyroScopeStore.swift
+++ b/talklat/talklat/Sources/Stores/GyroScopeStore.swift
@@ -6,32 +6,35 @@
 //
 
 import CoreMotion
-import CoreHaptics
 import Foundation
 import SwiftUI
 
 final class GyroScopeStore: ObservableObject {
     @Published private(set) var faced: FlippedStatus = .myself
     
-    private var rotationDegree: Double = 0.0
-    private let motionManager: CMMotionManager
+    private(set) var standardDegree: Double = 0.0
+    private(set) var rotationDegree: Double = 0.0
+    private var coreMotionManager: CMMotionManager?
     private let timeInterval: Double
     private let gyroScopeQueue: OperationQueue = OperationQueue()
-
+    private let writingDegreeLimit: Double = 130
+    private let recordingDegreeLimit: Double = 170
     
-    // MARK: INIT
+    ///initialzier
     init() {
-        motionManager = CMMotionManager()
-        timeInterval = 1.0 / 60.0
+        coreMotionManager = CMMotionManager()
+        timeInterval = 1.0 / 10.0
     }
     
-    // MARK: Motion을 감지할때 사용하는 메서드
-    // 다른 queue에서 motion을 감지합니다.
+    ///CoreMotion을 감지할때 사용하는 메서드
     public func detectDeviceMotion() {
+        guard let motionManager = coreMotionManager else { return }
+        
+        //MARK: 이 작업은 다른 queue에서 진행됨. UI업데이트만 Main Qeueue에서 진행
         if motionManager.isDeviceMotionAvailable {
-            self.motionManager.deviceMotionUpdateInterval = timeInterval
-            self.motionManager.showsDeviceMovementDisplay = true
-            self.motionManager.startDeviceMotionUpdates(
+            motionManager.deviceMotionUpdateInterval = timeInterval
+            motionManager.showsDeviceMovementDisplay = true
+            motionManager.startDeviceMotionUpdates(
                 using: .xArbitraryCorrectedZVertical,
                 to: gyroScopeQueue
             ) { [weak self] (data, error) in
@@ -39,35 +42,81 @@ final class GyroScopeStore: ObservableObject {
                     // MARK: roll, pitch, yaw를 전부 사용해서 attitude를 판단
                     self?.rotationDegree = abs(validData.attitude.pitch.toDegrees()) + abs(validData.attitude.roll.toDegrees()) + abs(validData.attitude.yaw.toDegrees())
                     
-                    // 실제 뷰의 UI를 변경하는 부분은 Main Queue에서 업데이트
-                    DispatchQueue.main.async {
-                        self?.faced = self?.motionStatusSetter(self?.rotationDegree) ?? .myself
+                    //y축 각속도가 2 이상일때
+                    if abs(validData.rotationRate.y) > 2 {
+                        //MARK: 실제 뷰의 UI를 변경하는 부분은 Main Queue에서 업데이트
+                        DispatchQueue.main.async {
+                            self?.faced = self?.motionStatusSetter(self?.rotationDegree) ?? .myself
+                        }
                     }
                 }
             }
         } else {
             // device에서 core motion을 지원 안할때
             // 근데 iOS 4.0 이상 전부 지원하니까 괜찮지 않을까 하는 생각
-//            fatalError("기기가 CoreMotion을 지원 안함")
+            //            fatalError("기기가 CoreMotion을 지원 안함")
             
         }
     }
     
-    // Mark: MotionManger를 멈출때 쓰는 메서드
+    ///MotionManger를 멈출때 쓰는 메서드
     public func stopMotionManager() {
-        self.motionManager.stopDeviceMotionUpdates()
+        guard let motionManager = self.coreMotionManager else { return }
+        motionManager.stopDeviceMotionUpdates()
     }
     
+    ///화면의 방향 및 모션에 따라 faced status를 설정하는 메서드
     private func motionStatusSetter(_ rotationDegree: Double?) -> FlippedStatus? {
         guard let degree = rotationDegree else { return nil }
-        switch degree {
-        case ...150:
-            return FlippedStatus.myself
-        case 151...300:
-            return FlippedStatus.opponent
-        default:
-            return FlippedStatus.myself
+        
+        let degreeDifference: Double = abs(degree - standardDegree)
+        let degreeArea: DegreeArea = checkArea(degree)
+        
+        // 새 값이 중립지역에서 관측되면 기준을 옮기지도 않고, 상태변화도 없음
+        guard degreeArea != .neutralArea else {
+            return self.faced
         }
+        
+        // 값이 너무 튈때(내가 화면을 보다가 눕힐때) 상태변화를 잡기 위한 guard
+        guard degreeDifference < 200 else {
+            return self.faced
+        }
+        
+        // 새로 관측된 지점이 중립지역이 아니니까 기준값을 새로 옮김
+        self.standardDegree = degree
+        
+        // 세팅할 화면을 정하는 기준
+        if degreeDifference < 40 { // 두 각의 차이가 40 이하
+            return self.faced
+        } else { // 두 각의 차이가 40도 이상
+            switch degreeArea { // 새로운 각값에 따라 화면이 보는 방향이 결정됨
+            case .writingArea:
+                return .myself
+            case .recordingArea:
+                return .opponent
+            default:
+                return self.faced
+            }
+        }
+    }
+    
+    /// 화면이 어느 영역(myself, neutral, opponent) 중 어느 영역에 있는지 확인하는 함수
+    private func checkArea(_ degree: Double) -> DegreeArea {
+        switch degree {
+        case ...writingDegreeLimit:
+            return .writingArea
+        case (writingDegreeLimit+1)...recordingDegreeLimit:
+            return .neutralArea
+        default:
+            return .recordingArea
+        }
+    }
+    
+    //사용자가 수동으로 motionManager를 재설정 가능한 함수
+    public func reinitialzie() {
+        self.coreMotionManager = nil
+        self.coreMotionManager = CMMotionManager()
+        self.detectDeviceMotion()
     }
 }
 
@@ -79,7 +128,6 @@ struct RotationTestView: View {
     var body: some View {
         VStack {
             Text(gyroStore.faced.rawValue)
-//            Text("\(gyroStore.rotationDegree)")
         }
         .onAppear {
             gyroStore.detectDeviceMotion()

--- a/talklat/talklat/Sources/Stores/GyroScopeStore.swift
+++ b/talklat/talklat/Sources/Stores/GyroScopeStore.swift
@@ -42,8 +42,8 @@ final class GyroScopeStore: ObservableObject {
                     // MARK: roll, pitch, yaw를 전부 사용해서 attitude를 판단
                     self?.rotationDegree = abs(validData.attitude.pitch.toDegrees()) + abs(validData.attitude.roll.toDegrees()) + abs(validData.attitude.yaw.toDegrees())
                     
-                    //y축 각속도가 2 이상일때
-                    if abs(validData.rotationRate.y) > 2 {
+                    let yVelocity: Double = abs(validData.rotationRate.y)
+                    if yVelocity > 2 {
                         //MARK: 실제 뷰의 UI를 변경하는 부분은 Main Queue에서 업데이트
                         DispatchQueue.main.async {
                             self?.faced = self?.motionStatusSetter(self?.rotationDegree) ?? .myself
@@ -70,7 +70,7 @@ final class GyroScopeStore: ObservableObject {
         guard let degree = rotationDegree else { return nil }
         
         let degreeDifference: Double = abs(degree - standardDegree)
-        let degreeArea: DegreeArea = checkArea(degree)
+        let degreeArea: EachCommunicationArea = checkArea(degree)
         
         // 새 값이 중립지역에서 관측되면 기준을 옮기지도 않고, 상태변화도 없음
         guard degreeArea != .neutralArea else {
@@ -101,7 +101,7 @@ final class GyroScopeStore: ObservableObject {
     }
     
     /// 화면이 어느 영역(myself, neutral, opponent) 중 어느 영역에 있는지 확인하는 함수
-    private func checkArea(_ degree: Double) -> DegreeArea {
+    private func checkArea(_ degree: Double) -> EachCommunicationArea {
         switch degree {
         case ...writingDegreeLimit:
             return .writingArea
@@ -113,7 +113,7 @@ final class GyroScopeStore: ObservableObject {
     }
     
     //사용자가 수동으로 motionManager를 재설정 가능한 함수
-    public func reinitialzie() {
+    public func reinitialize() {
         self.coreMotionManager = nil
         self.coreMotionManager = CMMotionManager()
         self.detectDeviceMotion()

--- a/talklat/talklat/Sources/Utilities/Constants.swift
+++ b/talklat/talklat/Sources/Utilities/Constants.swift
@@ -34,7 +34,7 @@ public enum FlippedStatus: String {
     case myself
 }
 
-public enum DegreeArea {
+public enum EachCommunicationArea {
     case writingArea
     case neutralArea
     case recordingArea

--- a/talklat/talklat/Sources/Utilities/Constants.swift
+++ b/talklat/talklat/Sources/Utilities/Constants.swift
@@ -33,3 +33,9 @@ public enum FlippedStatus: String {
     case opponent
     case myself
 }
+
+public enum DegreeArea {
+    case writingArea
+    case neutralArea
+    case recordingArea
+}


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->
<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `자이로를 이용한 flip 기능 안정화` | 
| :--- | :--- |
| 📜 **Description** | 영역전개와 각속도를 이용해 자이로를 안정화했습니다. |
| 📌 **Issue Number** | #51  |
| ![](https://img.shields.io/badge/-black?logo=figma)**Figma** | [Link](<!-- URL -->) |
| ![](https://img.shields.io/badge/-black?logo=notion)**Notion Card** | [Link](<!-- URL -->) |

---

## 작업 사항
1. 작업 내용
  - 자이로 로직을 수정했습니다. 이제는 중간에 neutral 지역(청인과 청각장애인 둘 사이의 지역)에서의 로직이 있습니다.
  - reinitialize함수가 추가됐습니다. 이 함수 누르면 현재 자기가 들고 있는 상황으로 자이로값이 초기화됩니다. 현재 UI쪽에서 conflict가 날까봐 건드리지 않고 있는데 추후에 TKRecordingView의 버튼을 눌렀을때 작동시킬 수 있도록 수정 해야겠습니다.
 

### `Logics`
1. motionStatusSetter 메서드에 변경이 생겼습니다. @mollangcow 와 대화를 해본 결과 .myself와 .opponent 사이에 중립 지역이 있어야 그 두 영역의 경계값에서 haptic이 너무 많은 횟수로 동작하는것을 막을 수 있다고 판단했습니다. 구현한 방법은 기존의 self.rotationDegree값이 150일때 바로 FlippedStatus를 나타내는 faced 변수를 변경한것과는 달리, 이전에 기록한 화면의 각도인 standardDegree 변수를 기준으로 40 이상 틀어지고, 중립지역에 화면이 있지 않으며, 그렇다고 값이 200이상 확 튀는 경우(.myself일때 화면을 천천히 눕히면 생기는 현상)도 아닌 경우에만 화면이 전환되도록 하였습니다.
![primage](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/22471820/dd5e9568-1373-421c-bfd6-9d7b4d268eb2)

```swift
// 세팅할 화면을 정하는 기준
        if degreeDifference < 40 { // 두 각의 차이가 40 이하
            return self.faced
        } else { // 두 각의 차이가 40도 이상
            switch degreeArea { // 새로운 각값에 따라 화면이 보는 방향이 결정됨
            case .writingArea:
                return .myself
            case .recordingArea:
                return .opponent
            default:
                return self.faced
            }
        }
```

2. @MADElinessss이 지속적으로 제시한 각속도를 이용해서 화면을 돌리지 않고도 천천히 수직방향으로 들어올리면 화면전환이 일어나는 버그를 고쳤습니다. 현재 y축 기준 각속도가 2 이상이어야 화면전환을 할지 말지 motionStatusSetter 메서드를 실행합니다. 이 부분은 인터널 쇼케이스 이후 소소한 값으 변경이 있을 수 있다고 생각합니다.

```swift
if abs(validData.rotationRate.y) > 2 {
          motionStatusSetter()
    }
}
```

4. 이 모든 방법이 통하지 않을때를 대비해서 아예 motionManager를 초기화하는 함수를 만들었습니다. 해당 함수를 실행시킨 순간의 화면의 위치를 사용자가 정면으로 바라보고 있다는 가정하에 motionManager를 reinitialize합니다. 이 부분은 UI의 머지가 다 끝나고 나서 붙히는게 맞다고 생각해서 아직 TKRecordingView의 버튼의 action에 넣지 않았습니다. 추후에 들어가야할 것 같습니다 @lianne-b 

---

## 작업 결과

---

#### 기타 공유사항

