### PR TITLE
[Fix/#55] TKRecordingview-Subtle-Bugfix

### DIFF
--- a/talklat/talklat/Sources/Stores/AppViewStore.swift
+++ b/talklat/talklat/Sources/Stores/AppViewStore.swift
@@ -46,6 +46,12 @@ final class AppViewStore: ObservableObject {
         }
     }
     
+    public func stopSpeechRecognizeButtonTapped() {
+        withAnimation(.easeIn(duration: 0.75)) {
+            communicationStatus = .writing
+        }
+    }
+    
     public func onWritingViewDisappear() {
         // TKHistoryView로 user's text 전달
         if !questionText.isEmpty {
@@ -59,18 +65,11 @@ final class AppViewStore: ObservableObject {
         print(questionText)
     }
     
-    public func onRecordingViewDisappear(transcript: String) {
+    public func onRecordingViewDisappear() {
         if let answeredText = answeredText,
-           !answeredText.isEmpty &&
-            !transcript.isEmpty {
+           !answeredText.isEmpty {
             let answerItem = HistoryItem(id: UUID(), text: answeredText, type: .answer)
             historyItems.append(answerItem)
-        }
-    }
-    
-    public func stopSpeechRecognizeButtonTapped() {
-        withAnimation(.easeIn(duration: 0.75)) {
-            communicationStatus = .writing
         }
     }
     

--- a/talklat/talklat/Sources/Views/TKRecordingView.swift
+++ b/talklat/talklat/Sources/Views/TKRecordingView.swift
@@ -17,73 +17,86 @@ struct TKRecordingView: View {
     }
 
     var body: some View {
-        ZStack {
-            VStack {
-                HStack {
-                    // 가이드 메세지 -> 이전 유저의 질문 텍스트가 있고 & 음성 인식이 시작되면 질문 텍스트로 변경
-                    if (!appViewStore.questionText.isEmpty && isRecording) {
-                        Text(appViewStore.questionText)
-                            .font(.system(size: 17, weight: .medium))
-                            .lineSpacing(10)
-                            .animation(.easeInOut, value: appViewStore.communicationStatus)
-                            .padding(.horizontal, 24)
-                            .padding(.top, 78)
-                            .frame(
-                                maxWidth: .infinity,
-                                alignment: .leading
-                            )
-                        //TODO: <이전 화면의 유저 질문 텍스트> 위치 이동 animation!
-                    } else {
-                        guideMessageBuilder()
-                    }
-                    Spacer()
-                }
-                
-                // 이전 화면의 유저의 질문 텍스트가 있을 때에만 표시
-                if (!appViewStore.questionText.isEmpty && !isRecording) {
-                    // 유저의 질문 텍스트
+        VStack {
+            HStack(alignment: .top) {
+                // 가이드 메세지 -> 이전 유저의 질문 텍스트가 있고 & 음성 인식이 시작되면 질문 텍스트로 변경
+                if !appViewStore.questionText.isEmpty && isRecording {
                     Text(appViewStore.questionText)
-                        .font(appViewStore.communicationStatus == .recording ? .title2 : .largeTitle)
-                        .bold()
-                        .lineSpacing(appViewStore.communicationStatus == .recording ? 10 : 14)
+                        .font(.headline)
+                        .lineSpacing(10)
                         .animation(.easeInOut, value: appViewStore.communicationStatus)
-                        .padding(.horizontal, 24)
-                        .padding(.top, 40)
-                        .frame(
-                            maxWidth: .infinity,
-                            alignment: .leading
-                        )
+                    //TODO: <이전 화면의 유저 질문 텍스트> 위치 이동 animation!
+                    
+                } else {
+                    guideMessageBuilder()
                 }
-                
-                Spacer()
-                // 음성 인식 텍스트
-                if(isRecording) {
-                    ZStack {
-                        VStack {
-                            Spacer()
-                            Rectangle()
-                                .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height * 0.55)
-                                .foregroundStyle(.gray.opacity(0.1))
-                        }
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 24)
+            .frame(
+                maxWidth: .infinity,
+                alignment: .leading
+            )
+            
+            // 이전 화면의 유저의 질문 텍스트가 있을 때에만 표시
+            if !appViewStore.questionText.isEmpty && !isRecording {
+                // 유저의 질문 텍스트
+                Text(appViewStore.questionText)
+                    .font(
+                        appViewStore.communicationStatus == .recording
+                        ? .title2
+                        : .largeTitle
+                    )
+                    .bold()
+                    .lineSpacing(
+                        appViewStore.communicationStatus == .recording
+                        ? 10
+                        : 14
+                    )
+                    .animation(
+                        .easeInOut,
+                        value: appViewStore.communicationStatus
+                    )
+                    .padding(.horizontal, 24)
+                    .padding(.top, 24)
+                    .frame(
+                        maxWidth: .infinity,
+                        alignment: .leading
+                    )
+            }
+            
+            Spacer()
+            
+            if isRecording {
+                Rectangle()
+                    .fill(Color.gray100)
+                    .frame(
+                        width: UIScreen.main.bounds.width,
+                        height: UIScreen.main.bounds.height * 0.55
+                    )
+                    .overlay(alignment: .topLeading) {
                         Text(speechRecognizeManager.transcript)
                             .font(.system(size: 24))
                             .bold()
                             .lineSpacing(14)
-                            .padding(.horizontal, 24)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .frame(
+                                maxWidth: .infinity,
+                                alignment: .leading
+                            )
                             .multilineTextAlignment(.leading)
-                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.top, 24)
+                            .padding(.horizontal, 24)
                     }
-                }
-            }
-            VStack {
-                Spacer()
-                recordButtonBuilder()
-                    .padding(.bottom, 40)
             }
         }
-        .ignoresSafeArea()
+        .overlay(alignment: .bottom) {
+            recordButtonBuilder()
+                .padding(.bottom, 40)
+        }
+        .frame(maxHeight: .infinity)
+        .ignoresSafeArea(edges: .bottom)
         .onAppear {
+            self.hideKeyboard()
             appViewStore.onRecordingViewAppear()
             speechRecognizeManager.startTranscribing()
         }
@@ -93,20 +106,14 @@ struct TKRecordingView: View {
                 speechRecognizeManager.startTranscribing()
             case .writing:
                 speechRecognizeManager.stopAndResetTranscribing()
+                appViewStore.onRecordingViewDisappear()
             }
         }
         .onChange(of: speechRecognizeManager.transcript) { transcript in
             if !transcript.isEmpty {
                 appViewStore.answeredTextSetter(transcript)
                 HapticManager.sharedInstance.generateHaptic(.light(times: countLastWord(transcript)))
-                print("===============================")
-                print("ANSWERED TEXT: ", transcript)
-                print("===============================")
             }
-        }
-        .onDisappear {
-            // TKHistoryView로 transcript 전달
-            appViewStore.onRecordingViewDisappear(transcript: speechRecognizeManager.transcript)
         }
     }
     
@@ -115,8 +122,6 @@ struct TKRecordingView: View {
             .font(.system(size: 24, weight: .medium))
             .multilineTextAlignment(.leading)
             .lineSpacing(12)
-            .padding(.horizontal, 24)
-            .padding(.top, 78)
             .foregroundColor(.gray)
     }
     
@@ -141,8 +146,6 @@ struct TKRecordingView: View {
 }
 
 struct TKRecordingView_Previews: PreviewProvider {
-    @State static var showHistoryView: Bool = false
-    
     static var previews: some View {
         TKRecordingView(
             appViewStore: AppViewStore.makePreviewStore { instance in


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->
<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `TKRecordingview-Subtle-Bugfix` | 
| :--- | :--- |
| 📜 **Description** | TKRecordingview에서 발생하는 사소한 버그들을 수정합니다. |
| 📌 **Issue Number** | #55 |
| ![](https://img.shields.io/badge/-black?logo=figma)**Figma** | _ |
| ![](https://img.shields.io/badge/-black?logo=notion)**Notion Card** | _ |

---

## 작업 사항
1. `SpeechManager`의 `transcript`의 생명주기가 끝나면서 `historyItem` init 시점에 `AppViewStore`의 `answeredText`만 참조하도록 수정
  - `onDisappear` 시점에 제대로 `HistoryItem`을 생성하지 못하는 조건문 수정
  - `communicationStatus`의 변화에 따라 `HistoryItem`을 생성하도록 조정
2. `ZStack` 기반의 `View`가 다른 상위 뷰에서 보여질 때, 간혹 Layout 상대성을 잃는 이슈에 기인하여 overlay 기분으로 수정
3. RecordingView가 보여질 때, keyboard를 자동으로 숨김 처리
  - `onAppear` 시점에 호출

### `Logics`

```diff
- public func onRecordingViewDisappear(transcript: String) {
+ public func onRecordingViewDisappear() {
  if let answeredText = answeredText,
-     !answeredText.isEmpty && !transcript.isEmpty {
+     !answeredText.isEmpty {
    let answerItem = HistoryItem(id: UUID(), text: answeredText, type: .answer)
    historyItems.append(answerItem)
  }
}

///

.onChange(of: appViewStore.communicationStatus) { communicationStatus in
  switch communicationStatus {
  case .recording:
    speechRecognizeManager.startTranscribing()
  case .writing:
+   speechRecognizeManager.stopAndResetTranscribing()
    appViewStore.onRecordingViewDisappear()
  }
}
```

---

## 작업 결과
<!-- 이미지, gif 등을 캡쳐하여 첨부합니다. -->
<!-- 해당 섹션은 필수가 아닙니다! -->
- UI 변동은 없습니다!

---

#### 기타 공유사항
<!-- 야기될 수 있는 사이드 이펙트, 조사가 필요한 내용 등을 작성합니다. --> 
1. 일전에 말씀드린대로, `TKCommunicationView`가 각 `View`의 컴포넌트를 레이아웃할 예정입니다.
  - `TKWritingView`와 `TKRecordingView`는 사라지고, 각 View를 그리기 위한 `@ViewBuilder`를 관리하는 `Manager` 타입 구조체가 생길 수 있습니다(미정)
  - cc. @MADElinessss, @alpaka99, @lianne-b 

