### PR TITLE
Hotfix/#60 internal showcase quick feedback

### DIFF
--- a/talklat/talklat/Sources/Stores/AppViewStore.swift
+++ b/talklat/talklat/Sources/Stores/AppViewStore.swift
@@ -41,13 +41,13 @@ final class AppViewStore: ObservableObject {
     
     // MARK: HELPERS
     public func enterSpeechRecognizeButtonTapped() {
-        withAnimation(.easeIn(duration: 0.75)) {
+        withAnimation(.easeIn(duration: 0.15)) {
             communicationStatus = .recording
         }
     }
     
     public func stopSpeechRecognizeButtonTapped() {
-        withAnimation(.easeIn(duration: 0.75)) {
+        withAnimation(.easeIn(duration: 0.15)) {
             communicationStatus = .writing
         }
     }
@@ -152,7 +152,7 @@ final class AppViewStore: ObservableObject {
 // MARK: public Setters
 extension AppViewStore {
     public func communicationStatusSetter(_ status: CommunicationStatus) {
-        withAnimation(.easeIn(duration: 0.75)) {
+        withAnimation(.easeIn(duration: 0.15)) {
             communicationStatus = status
         }
     }

--- a/talklat/talklat/Sources/Views/Components/TLTextField.swift
+++ b/talklat/talklat/Sources/Views/Components/TLTextField.swift
@@ -57,7 +57,8 @@ struct TLTextField<Button: View>: View {
                 text: $text,
                 axis: .vertical
             )
-            .font(.system(size: 20, weight: .bold))
+            .font(.title3)
+            .bold()
             .lineSpacing(12)
             .padding(.horizontal, 24)
             .frame(maxWidth: .infinity)

--- a/talklat/talklat/Sources/Views/TKWritingView.swift
+++ b/talklat/talklat/Sources/Views/TKWritingView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct TKWritingView: View {
     @ObservedObject var appViewStore: AppViewStore
     @FocusState var focusState: Bool
+    @FocusState var neverFocus: Bool
     
     private var hasQuestionTextReachedMaximumCount: Bool {
         appViewStore.questionText.count == appViewStore.questionTextLimit
@@ -18,49 +19,32 @@ struct TKWritingView: View {
     // MARK: - BODY
     var body: some View {
         VStack {
-            // (Test용) TKHistoryView로 이동하는 부분
             // TODO: Upper Chevron
             if let lastItem = appViewStore.historyItems.last,
                lastItem.type == .answer {
-                ZStack(alignment: .top) {
-                    RoundedRectangle(cornerRadius: 12)
-                        .frame(
-                            width: UIScreen.main.bounds.width * 0.9,
-                            height: UIScreen.main.bounds.height * 0.2
-                        )
-                        .foregroundStyle(.gray.opacity(0.1))
-                    
-                    HStack {
-                        Image(systemName: "waveform.circle.fill")
-                            .resizable()
-                            .frame(width: 20, height: 20)
-                            .foregroundColor(Color(.systemGray))
-                            .padding(.top, 24)
-                            .padding(.leading, 40)
-                            .transition(
-                                .move(edge: .bottom)
-                                .combined(with: .opacity)
-                            )
-                        
-                        Spacer()
+                VStack {
+                    ScrollView {
+                        Text(lastItem.text)
+                            .font(.title3)
+                            .bold()
+                            .lineSpacing(8)
                     }
+                    .frame(height: 200)
                     
-                    Text("        " + lastItem.text)
-                        .font(.headline)
-                        .bold()
-                        .lineSpacing(10)
-                        .frame(
-                            maxWidth: .infinity,
-                            alignment: .leading
-                        )
-                        .padding(.top, 24)
-                        .padding(.horizontal, 40)
-                        .transition(
-                            .move(edge: .bottom)
-                            .combined(with: .opacity)
-                        )
+                    Divider()
+                    
+                    Image(systemName: "waveform.circle.fill")
                 }
+                .padding(.vertical, 24)
+                .padding(.horizontal, 40)
+                .background {
+                    RoundedRectangle(cornerRadius: 12)
+                        .foregroundStyle(.gray.opacity(0.1))
+                        .padding(.horizontal)
+                }
+                .padding(.top, 16)
             }
+            
             TLTextField(
                 style: .normal(textLimit: 160),
                 text: Binding(
@@ -93,21 +77,22 @@ struct TKWritingView: View {
             .padding(.top, 24)
             
             Spacer()
-            
+        }
+        .overlay(alignment: .bottom) {
             Button {
                 appViewStore.enterSpeechRecognizeButtonTapped()
+                HapticManager.sharedInstance.generateHaptic(.rigidTwice)
             } label: {
                 Text("**음성 인식 전환**")
                     .foregroundColor(.white)
                     .padding(.horizontal, 25)
-                    .padding(.vertical, 22)
+                    .padding(.vertical, 20)
                     .background {
                         Capsule()
                             .foregroundColor(.gray)
                     }
             }
             .padding(.bottom, 20)
-            
         }
         .onAppear {
             appViewStore.onWritingViewAppear()
@@ -139,9 +124,8 @@ struct TKWritingView_Previews: PreviewProvider {
         NavigationStack {
             TKWritingView(appViewStore: AppViewStore.makePreviewStore {
                 instance in
-                instance.questionTextSetter("test")
-                instance.historyItems.append(.init(id: .init(), text: "dfdf", type: .answer))
-                instance.historyItems.append(.init(id: .init(), text: "sdf", type: .question))
+                instance.answeredTextSetter("testtesttesttesttesttesttest")
+                instance.historyItems.append(.init(id: .init(), text: "A long string of text that goes on an A long string of text A long string of text that goes on an A long string of text that goes on an A long string of text that goes on an ", type: .answer))
             })
         }
     }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->
<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `internal showcase quick feedback` | 
| :--- | :--- |
| 📜 **Description** | 내부 쇼케이스 빌드를 위한 빠른 피드백 사항들을 반영합니다. |
| 📌 **Issue Number** | #60  |
| ![](https://img.shields.io/badge/-black?logo=figma)**Figma** | _ |
| ![](https://img.shields.io/badge/-black?logo=notion)**Notion Card** | _ |

---

## 작업 사항
<!-- 1. MainIntroView의 ScrollView 구현 -->
1. `.font`의 사이즈를 SwiftUI API로 수정하여 Dynamic Font 대응
2. AnsweredText를 보여주는 Card를 Scrollable 하게 개선
3. Animation과 Transition 속도 향상
4. 기타 padding, linespacing 등의 값 수정

### `Logics`
1. 큰 변동사항이 없어서 생략합니다.

---

## 작업 결과
<!-- 이미지, gif 등을 캡쳐하여 첨부합니다. -->
<!-- 해당 섹션은 필수가 아닙니다! -->
![simulator_screenshot_5E4098C4-E172-4017-8058-3F8D033EBAAE](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/3322cdda-8b84-413f-8d19-65a21d31a49f)

---

#### 기타 공유사항
<!-- 야기될 수 있는 사이드 이펙트, 조사가 필요한 내용 등을 작성합니다. --> 
1. 자잘한 UI 업데이트와 관련된 내용을 포함하여 `TKCommunicationView`가 새로 구현될 예정입니다.
2. 현재 AnsweredTextCard가 multiline을 center로 보여주고 있는 현상도 개선 예정입니다.