### PR TITLE
[Feat/#52] 음성인식 2번째 이후 가이딩메세지 추가

### DIFF
--- a/talklat/talklat/Sources/Stores/AppViewStore.swift
+++ b/talklat/talklat/Sources/Stores/AppViewStore.swift
@@ -19,6 +19,7 @@ final class AppViewStore: ObservableObject {
     @Published private(set) var currentAuthStatus: AuthStatus = .authIncompleted
     @Published private(set) var hasGuidingMessageShown: Bool = false
     @Published public var historyItems: [HistoryItem] = []
+    @Published var recognitionCount: Int = 0
     
     @Published public var deviceHeight: CGFloat = CGFloat(0)
     @Published public var isHistoryViewShown: Bool = false

--- a/talklat/talklat/Sources/Utilities/Constants.swift
+++ b/talklat/talklat/Sources/Utilities/Constants.swift
@@ -20,6 +20,13 @@ public enum Constants {
     말씀하신 내용은 음성인식되어서
     텍스트로 변환됩니다.
     """
+    
+    static let SECOND_GUIDE_MESSAGE: String =
+    """
+    저는 청각장애가 있어요.
+    말씀하신 내용은 음성인식되어서
+    텍스트로 변환됩니다.
+    """
 }
 
 public enum AuthStatus: String {

--- a/talklat/talklat/Sources/Views/TKRecordingView.swift
+++ b/talklat/talklat/Sources/Views/TKRecordingView.swift
@@ -91,6 +91,7 @@ struct TKRecordingView: View {
             switch communicationStatus {
             case .recording:
                 speechRecognizeManager.startTranscribing()
+                appViewStore.recognitionCount += 1
             case .writing:
                 speechRecognizeManager.stopAndResetTranscribing()
             }
@@ -111,7 +112,14 @@ struct TKRecordingView: View {
     }
     
     private func guideMessageBuilder() -> some View {
-        Text(Constants.GUIDE_MESSAGE)
+        let message: String
+        if appViewStore.recognitionCount == 0 {
+            message = Constants.GUIDE_MESSAGE
+        } else {
+            message = Constants.SECOND_GUIDE_MESSAGE
+        }
+        
+        return Text(message)
             .font(.system(size: 24, weight: .medium))
             .multilineTextAlignment(.leading)
             .lineSpacing(12)


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- 녹음인식 2번째 이후 가이딩메세지 추가 -->
<!-- Issue Link: #52  -->
<!-- Figma: Link (선택) -->
<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `녹음인식 2번째 이후 가이딩메세지 추가` | 
| :--- | :--- |
| 📜 **Description** | 녹음인식 2번째 이후의 가이딩메세지를 추가했습니다|
| 📌 **Issue Number** | <!-- #52 --> |
| ![](https://img.shields.io/badge/-black?logo=figma)**Figma** | [Link](<!-- URL -->) |
| ![](https://img.shields.io/badge/-black?logo=notion)**Notion Card** | [Link](<!-- URL -->) |

---

## 작업 사항
1. 음성인식이 2번째 이후이면, 두번째 가이딩메세지를 추가했습니다.
  - 쇼케이스 전날했던 작업인데,,너무 간단하지만 얼른 올려놓고 다음 작업하겠습니당

