### PR TITLE
Feat/#63 TKCommunicationView 구현

### DIFF
--- a/talklat/talklat.xcodeproj/project.pbxproj
+++ b/talklat/talklat.xcodeproj/project.pbxproj
@@ -12,9 +12,10 @@
 		57806D722ADEB8FD003A7B19 /* TKWritingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF7378E2AD3DCE500FCBA21 /* TKWritingView.swift */; };
 		57806D802AE28ED3003A7B19 /* HistoryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57806D7F2AE28ED3003A7B19 /* HistoryItem.swift */; };
 		57E76EB72ACEC91A00D79553 /* StaffSpeechView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E76EB62ACEC91A00D79553 /* StaffSpeechView.swift */; };
+		7E427EE12AE9559D0028E4F4 /* CommunicationViewStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E427EE02AE9559D0028E4F4 /* CommunicationViewStore.swift */; };
 		7E8445DA2ADFB4FC00CFB8BC /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8445D92ADFB4FC00CFB8BC /* Color+Hex.swift */; };
 		7E8445DE2ADFBBD900CFB8BC /* TKColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8445DD2ADFBBD900CFB8BC /* TKColor.swift */; };
-		7E8906412ACEA31500C9947A /* TKIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8906402ACEA31500C9947A /* TKIntroView.swift */; };
+		7E8906412ACEA31500C9947A /* TKCommunicationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8906402ACEA31500C9947A /* TKCommunicationView.swift */; };
 		7E8D17D62ACE8AED00E904E5 /* talklatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17D52ACE8AED00E904E5 /* talklatTests.swift */; };
 		7E8D17E02ACE8AED00E904E5 /* talklatUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17DF2ACE8AED00E904E5 /* talklatUITests.swift */; };
 		7E8D17E22ACE8AED00E904E5 /* talklatUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17E12ACE8AED00E904E5 /* talklatUITestsLaunchTests.swift */; };
@@ -59,9 +60,10 @@
 		57806D702ADC5D19003A7B19 /* TestHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHistoryView.swift; sourceTree = "<group>"; };
 		57806D7F2AE28ED3003A7B19 /* HistoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryItem.swift; sourceTree = "<group>"; };
 		57E76EB62ACEC91A00D79553 /* StaffSpeechView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaffSpeechView.swift; sourceTree = "<group>"; };
+		7E427EE02AE9559D0028E4F4 /* CommunicationViewStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunicationViewStore.swift; sourceTree = "<group>"; };
 		7E8445D92ADFB4FC00CFB8BC /* Color+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Hex.swift"; sourceTree = "<group>"; };
 		7E8445DD2ADFBBD900CFB8BC /* TKColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKColor.swift; sourceTree = "<group>"; };
-		7E8906402ACEA31500C9947A /* TKIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKIntroView.swift; sourceTree = "<group>"; };
+		7E8906402ACEA31500C9947A /* TKCommunicationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKCommunicationView.swift; sourceTree = "<group>"; };
 		7E8D17C12ACE8AEC00E904E5 /* talklat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = talklat.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E8D17C42ACE8AEC00E904E5 /* talklatApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = talklatApp.swift; sourceTree = "<group>"; };
 		7E8D17C82ACE8AED00E904E5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -201,7 +203,7 @@
 			isa = PBXGroup;
 			children = (
 				7EF737952AD43E8300FCBA21 /* Components */,
-				7E8906402ACEA31500C9947A /* TKIntroView.swift */,
+				7E8906402ACEA31500C9947A /* TKCommunicationView.swift */,
 				7EF7378E2AD3DCE500FCBA21 /* TKWritingView.swift */,
 				7EF737902AD3DCF900FCBA21 /* TKRecordingView.swift */,
 				EF67C6562AD1414300C1074E /* AuthorizationRequestView.swift */,
@@ -218,6 +220,7 @@
 			isa = PBXGroup;
 			children = (
 				7EF7378B2AD3C87700FCBA21 /* AppViewStore.swift */,
+				7E427EE02AE9559D0028E4F4 /* CommunicationViewStore.swift */,
 				7EA8A78A2AD502D600AFD687 /* GyroScopeStore.swift */,
 			);
 			path = Stores;
@@ -398,7 +401,7 @@
 				7EF737912AD3DCF900FCBA21 /* TKRecordingView.swift in Sources */,
 				CEF43C482ADA97FF00DE02A9 /* HapticManager.swift in Sources */,
 				EF90C5212AE0FE9E00A95BD7 /* SwipeGuideMessage.swift in Sources */,
-				7E8906412ACEA31500C9947A /* TKIntroView.swift in Sources */,
+				7E8906412ACEA31500C9947A /* TKCommunicationView.swift in Sources */,
 				7EF737942AD3DE5600FCBA21 /* Constants.swift in Sources */,
 				7EF7378C2AD3C87700FCBA21 /* AppViewStore.swift in Sources */,
 				7EFA2C2B2AD51FC80013B533 /* Double+Degree.swift in Sources */,
@@ -413,6 +416,7 @@
 				57806D712ADC5D19003A7B19 /* TestHistoryView.swift in Sources */,
 				7EE087E82ADD4FAE00E07720 /* TKHistoryView.swift in Sources */,
 				EF67C64B2ACEB67000C1074E /* SpeechRecognizer.swift in Sources */,
+				7E427EE12AE9559D0028E4F4 /* CommunicationViewStore.swift in Sources */,
 				EF67C6572AD1414300C1074E /* AuthorizationRequestView.swift in Sources */,
 				7EA8A78B2AD502D600AFD687 /* GyroScopeStore.swift in Sources */,
 			);

--- a/talklat/talklat/Sources/Models/HistoryItem.swift
+++ b/talklat/talklat/Sources/Models/HistoryItem.swift
@@ -7,11 +7,12 @@
 
 import Foundation
 
-struct HistoryItem: Identifiable {
-    var id: UUID
+struct HistoryItem: Identifiable, Equatable {
     enum MessageType {
         case question, answer
     }
+    
+    var id: UUID
     let text: String
     let type: MessageType
 }

--- a/talklat/talklat/Sources/Stores/CommunicationViewStore.swift
+++ b/talklat/talklat/Sources/Stores/CommunicationViewStore.swift
@@ -1,0 +1,8 @@
+//
+//  CommunicationViewStore.swift
+//  talklat
+//
+//  Created by Celan on 10/25/23.
+//
+
+import Foundation

--- a/talklat/talklat/Sources/Stores/CommunicationViewStore.swift
+++ b/talklat/talklat/Sources/Stores/CommunicationViewStore.swift
@@ -5,4 +5,134 @@
 //  Created by Celan on 10/25/23.
 //
 
-import Foundation
+import SwiftUI
+
+final class CommunicationViewStore: ObservableObject {
+    enum CommunicationStatus: Equatable {
+        case recording
+        case writing
+    }
+    
+    struct CommunicationState: Equatable {
+        var communicationStatus: CommunicationStatus
+        var questionText: String = ""
+        var answeredText: String = ""
+        var hasGuidingMessageShown: Bool = false
+        var hasChevronButtonTapped: Bool = false
+        var historyItems: [HistoryItem] = []
+        var historyItem: HistoryItem?
+    }
+    
+    @Published private var viewState: CommunicationState
+    public let questionTextLimit: Int = 160
+    
+    // MARK: init
+    init(
+        communicationState: CommunicationState
+    ) {
+        self.viewState = communicationState
+    }
+    
+    public func callAsFunction<Value: Equatable>(_ keyPath: KeyPath<CommunicationState, Value>) -> Value {
+        self.viewState[keyPath: keyPath]
+    }
+    
+    // MARK: Helpers
+    public func bindingQuestionText() -> Binding<String> {
+        Binding(
+            get: { self.viewState.questionText },
+            set: {
+                if $0.count > self.questionTextLimit {
+                    self.updateState(
+                        \.questionText,
+                         with: String($0.prefix(self.questionTextLimit))
+                    )
+                } else {
+                    self.updateState(
+                        \.questionText,
+                         with: $0
+                    )
+                }
+            }
+        )
+    }
+    
+    public func onWritingViewAppear() {
+        self.updateState(\.questionText, with: "")
+        self.updateState(\.historyItem, with: HistoryItem(id: .init(), text: self(\.answeredText), type: .answer))
+        self.updateState(\.communicationStatus, with: .writing)
+        HapticManager.sharedInstance.generateHaptic(.rigidTwice)
+        
+    }
+    
+    public func onRecordingViewAppear() {
+        self.updateState(\.answeredText, with: "")
+        self.updateState(\.historyItem, with: HistoryItem(id: .init(), text: self(\.questionText), type: .question))
+        
+        self.updateState(\.communicationStatus, with: .recording)
+        HapticManager.sharedInstance.generateHaptic(.success)
+
+    }
+    
+    public func onStartRecordingButtonTapped() {
+        self.onRecordingViewAppear()
+    }
+    
+    public func onEraseAllButtonTapped() {
+        self.updateState(\.questionText, with: "")
+    }
+    
+    public func onStopRecordingButtonTapped() {
+        self.onWritingViewAppear()
+    }
+    
+    public func onChevronButtonTapped() {
+        self.updateState(
+            \.hasChevronButtonTapped,
+             with: self(\.hasChevronButtonTapped)
+             ? false
+             : true
+        )
+    }
+    
+    public func onSpeechTransicriptionUpdated(_ str: String) {
+        self.updateState(\.answeredText, with: str)
+        self.updateState(\.hasGuidingMessageShown, with: true)
+        HapticManager.sharedInstance.generateHaptic(.light(times: countLastWord(str)))
+    }
+    
+    private func countLastWord(_ transcript: String) -> Int {
+        return transcript.components(separatedBy: " ").last?.count ?? 0
+    }
+}
+
+// MARK: Reduce
+extension CommunicationViewStore {
+    /// ViewState를 업데이트하는 keyPath 기반 메소드
+    /// 일반적인 경우, default 만으로 대응이 가능하나, 특별한 로직이 필요할 경우 할당하는 로직을 케이스로 추가할 수 있다.
+    /// - Parameters:
+    ///   - state: 업데이트할 ViewState의 속성 전달
+    ///   - newValue: 새로 업데이트할 ViweState의 값 전달
+    private func updateState<Value: Equatable>(
+        _ state: WritableKeyPath<CommunicationState, Value>,
+        with newValue: Value
+    ) {
+        switch state {
+        case \.historyItem:
+            self.viewState[keyPath: state] = newValue
+            if let newHistoryItem = self.viewState.historyItem {
+                self.viewState.historyItems.append(newHistoryItem)
+            }
+        case \.hasGuidingMessageShown:
+            withAnimation {
+                self.viewState[keyPath: state] = newValue
+            }
+            
+        case \.historyItems:
+            break
+            
+        default:
+            self.viewState[keyPath: state] = newValue
+        }
+    }
+}

--- a/talklat/talklat/Sources/Utilities/Constants.swift
+++ b/talklat/talklat/Sources/Utilities/Constants.swift
@@ -40,3 +40,9 @@ public enum EachCommunicationArea {
     case neutralArea
     case recordingArea
 }
+
+public enum TKTransitionObjects {
+    case QUESTION
+    case ANSWER
+    case INTERLUDE
+}

--- a/talklat/talklat/Sources/Views/Components/TLTextField.swift
+++ b/talklat/talklat/Sources/Views/Components/TLTextField.swift
@@ -60,6 +60,7 @@ struct TLTextField<Button: View>: View {
             .font(.title3)
             .bold()
             .lineSpacing(12)
+            .lineLimit(5, reservesSpace: true)
             .padding(.horizontal, 24)
             .frame(maxWidth: .infinity)
             .autocorrectionDisabled()

--- a/talklat/talklat/Sources/Views/ScrollContainer.swift
+++ b/talklat/talklat/Sources/Views/ScrollContainer.swift
@@ -23,14 +23,14 @@ struct ScrollContainer: View {
                                 .frame(maxWidth: .infinity)
                                 .id("TKHistoryView")
                             
-                            TKIntroView(appViewStore: appViewStore)
-                                .padding(.top, -10) /// View 사이의 디폴트 공백 제거
-                                .frame(
-                                    height: geo.size.height + geo.safeAreaInsets.magnitude
-                                )
-                                .frame(maxWidth: .infinity)
-                                .background(Color.white)
-                                .id("TKIntroView")
+//                            TKCommunicationView(appViewStore: appViewStore)
+//                                .padding(.top, -10) /// View 사이의 디폴트 공백 제거
+//                                .frame(
+//                                    height: geo.size.height + geo.safeAreaInsets.magnitude
+//                                )
+//                                .frame(maxWidth: .infinity)
+//                                .background(Color.white)
+//                                .id("TKIntroView")
                         }
                         .onAppear {
                             appViewStore.onIntroViewAppear(proxy)

--- a/talklat/talklat/Sources/Views/TKCommunicationView.swift
+++ b/talklat/talklat/Sources/Views/TKCommunicationView.swift
@@ -5,45 +5,190 @@
 //  Created by Celan on 2023/10/05.
 //
 
+import Combine
 import SwiftUI
 
 struct TKCommunicationView: View {
     @Environment(\.scenePhase) private var scenePhase
-    @StateObject var gyroMotionStore: GyroScopeStore = GyroScopeStore()
-    @ObservedObject var appViewStore: AppViewStore
+    @FocusState var focusState: Bool
+    @Namespace var communicationAnimation
     
+    @StateObject private var speechRecognizeManager: SpeechRecognizer = SpeechRecognizer()
+    @StateObject private var gyroScopeStore: GyroScopeStore = GyroScopeStore()
+    @StateObject private var store: CommunicationViewStore = CommunicationViewStore(
+        communicationState: CommunicationViewStore.CommunicationState(
+            communicationStatus: .writing,
+            questionText: "A long string of text that goes on an A long string of text A long string of text that goes on an A long string of text that goes on an A long string of text that goes on an that goes on an text that goes on an A long"
+        )
+    )
+    
+    // MARK: Body
     var body: some View {
         VStack {
-            Group {
-                switch appViewStore.communicationStatus {
-                case .writing:
-                    TKWritingView(appViewStore: appViewStore)
-                        .transition(.opacity)
+            if store(\.communicationStatus) == .writing {
+                if let historyItem = store(\.historyItems).last,
+                   !store(\.answeredText).isEmpty {
+                    answerTextCardViewBuilder(historyItem)
+                        .padding(.top, 32)
+                        .transition(
+                            .asymmetric(
+                                insertion: .opacity,
+                                removal: .move(edge: .top)
+                            )
+                        )
+                        .animation(.easeInOut, value: store(\.communicationStatus))
+                        .matchedGeometryEffect(
+                            id: 
+                                store(\.communicationStatus) == .writing
+                                ? TKTransitionObjects.ANSWER
+                                : TKTransitionObjects.INTERLUDE
+                            ,
+                            in: communicationAnimation
+                        )
+                        .overlay(alignment: .top) {
+                            if !store(\.historyItems).isEmpty {
+                                chevronButtonBuilder()
+                            }
+                        }
+                }
+                
+                // MARK: TEXTFIELD ITEM ANIMATIONS DONE
+                // TODO: TEXTFIELD -> QUESTIONTEXT matching
+                TLTextField(
+                    style: .normal(textLimit: 160),
+                    text: store.bindingQuestionText(),
+                    placeholder: "탭해서 전하고 싶은 내용을 작성해 주세요."
+                ) {
+                    eraseAllButtonBuilder()
+                        .opacity(focusState ? 1.0 : 0.0)
+                        .animation(.easeInOut(duration: 0.2), value: focusState)
+                }
+                .focused($focusState)
+                .overlay(alignment: .topLeading) {
+                    characterLimitViewBuilder()
+                        .padding(.leading, 24)
+                        .padding(.top, 36)
+                        .opacity(focusState ? 1.0 : 0.0)
+                        .animation(.easeInOut(duration: 0.4), value: focusState)
+                }
+                .padding(.top, 24)
+                .matchedGeometryEffect(
+                    id: store(\.communicationStatus) == .writing
+                    ? TKTransitionObjects.QUESTION
+                    : TKTransitionObjects.INTERLUDE,
+                    in: communicationAnimation
+                )
+                
+                Spacer()
+            }
+            
+            if store(\.communicationStatus) == .recording {
+                if !store(\.hasGuidingMessageShown) {
+                    guideMessageBuilder()
+                        .padding(.top, 24)
                     
-                case .recording:
-                    TKRecordingView(appViewStore: appViewStore)
-                        .transition(.opacity)
+                } else if store(\.hasGuidingMessageShown) {
+                    EmptyView()
+                }
+                
+                ScrollView {
+                    Text(store(\.questionText))
+                        .font(
+                            store(\.answeredText).isEmpty
+                            ? .title2
+                            : .headline
+                        )
+                        .foregroundColor(
+                            store(\.answeredText).isEmpty
+                            ? .gray900
+                            : .gray700
+                        )
+                        .lineSpacing(10)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 24)
+                        
+                }
+                .padding(.top, 24)
+                .frame(height: 250)
+                .scrollIndicators(.hidden)
+                .animation(.none, value: store(\.communicationStatus))
+                .transition(
+                    .asymmetric(
+                        insertion: .move(edge: .bottom),
+                        removal: .move(edge: .top)
+                    )
+                )
+                .animation(.easeOut, value: store(\.communicationStatus))
+                .matchedGeometryEffect(
+                    id: store(\.communicationStatus) == .writing
+                    ? TKTransitionObjects.QUESTION
+                    : TKTransitionObjects.INTERLUDE,
+                    in: communicationAnimation
+                )
+                .onChange(of: speechRecognizeManager.transcript) { transcript in
+                    store.onSpeechTransicriptionUpdated(transcript)
+                }
+                
+                Spacer()
+                
+                if !store(\.answeredText).isEmpty {
+                    ScrollView {
+                        Text(store(\.answeredText))
+                            .font(.title2)
+                            .bold()
+                            .lineSpacing(12)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 24)
+                            .padding(.top, 24)
+                    }
+                    .padding(.top, 12)
+                    .background { Color.gray100.ignoresSafeArea(edges: .bottom) }
+                    .scrollIndicators(.hidden)
+                    .matchedGeometryEffect(
+                        id: TKTransitionObjects.ANSWER,
+                        in: communicationAnimation
+                    )
                 }
             }
         }
-        // TODO: - 디자인 팀이랑 상의 후 패딩 값 조절 (전체 지우기, swipeGuideMessage의 거리 등)
-//        .safeAreaInset(edge: .top) {
-//            Rectangle()
-//                .fill(.white)
-//            // TODO: - deviceTopSafeAreaInset 값으로 변경
-//                .frame(height: 50)
-//        }
-        .onAppear {
-            gyroMotionStore.detectDeviceMotion()
+        .animation(.spring(), value: store(\.communicationStatus))
+        .onTapGesture {
+            self.hideKeyboard()
         }
-        .onChange(of: gyroMotionStore.faced) { facedStatus in
+        .safeAreaInset(edge: .bottom) {
+            if store(\.communicationStatus) == .writing {
+                startRecordingButtonBuilder()
+            } else if store(\.communicationStatus) == .recording {
+                stopRecordButtonBuilder()
+                    .padding(.top, 12)
+                    .frame(maxWidth: .infinity)
+                    .background {
+                        store(\.answeredText).isEmpty
+                        ? Color.white.ignoresSafeArea(edges: .bottom)
+                        : Color.gray100.ignoresSafeArea(edges: .bottom)
+                    }
+            }
+        }
+        .onAppear {
+            gyroScopeStore.detectDeviceMotion()
+        }
+        .onChange(of: store(\.communicationStatus)) { newStatus in
+            switch newStatus {
+            case .writing:
+                speechRecognizeManager.stopAndResetTranscribing()
+                
+            case .recording:
+                speechRecognizeManager.startTranscribing()
+                
+            }
+        }
+        .onChange(of: gyroScopeStore.faced) { facedStatus in
             switch facedStatus {
             case .myself:
-                appViewStore.communicationStatusSetter(.writing)
-                HapticManager.sharedInstance.generateHaptic(.rigidTwice)
+                store.onWritingViewAppear()
+                
             case .opponent:
-                appViewStore.communicationStatusSetter(.recording)
-                HapticManager.sharedInstance.generateHaptic(.success)
+                store.onRecordingViewAppear()
             }
         }
         .onChange(of: scenePhase) { _ in
@@ -52,17 +197,128 @@ struct TKCommunicationView: View {
     }
 }
 
-struct TKIntroView_Previews: PreviewProvider {
-    static var previews: some View {
-        TKCommunicationView(
-            appViewStore: .makePreviewStore(condition: { store in
-                store.questionTextSetter("")
-                store.voiceRecordingAuthSetter(.authCompleted)
-                store.communicationStatusSetter(.writing)
-            })
-        )
+// TODO: Component Container..?
+extension TKCommunicationView {
+    private func eraseAllButtonBuilder() -> some View {
+        Button {
+            store.onEraseAllButtonTapped()
+        } label: {
+            Text("전체 지우기")
+                .foregroundColor(
+                    store(\.questionText).isEmpty
+                    ? .gray.opacity(0.5)
+                    : .gray
+                )
+        }
+    }
+    
+    private func answerTextCardViewBuilder(_ lastItem: HistoryItem) -> some View {
+        VStack {
+            ScrollView {
+                Text(lastItem.text)
+                    .font(.title3)
+                    .lineSpacing(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(height: 200)
+        }
+        .padding(.vertical, 24)
+        .padding(.horizontal, 40)
+        .background {
+            RoundedRectangle(cornerRadius: 12)
+                .foregroundColor(.gray100)
+                .padding(.horizontal, 20)
+        }
+    }
+    
+    private func startRecordingButtonBuilder() -> some View {
+        Button {
+            store.onStartRecordingButtonTapped()
+            speechRecognizeManager.startTranscribing()
+            
+        } label: {
+            Text("**음성 인식 전환**")
+                .foregroundColor(.white)
+                .padding(.horizontal, 25)
+                .padding(.vertical, 20)
+                .background {
+                    Capsule()
+                        .foregroundColor(.gray)
+                }
+        }
+    }
+    
+    private func characterLimitViewBuilder() -> some View {
+        Text("\(store(\.questionText).count)/\(store.questionTextLimit)")
+            .font(.system(size: 12, weight: .regular))
+            .monospacedDigit()
+            .foregroundColor(
+                hasQuestionTextReachedMaximumCount
+                ? .red
+                : .gray
+            )
+    }
+    
+    private func chevronButtonBuilder() -> some View {
+        VStack {
+            if store(\.hasChevronButtonTapped) {
+                Text("위로 스와이프해서 내용을 더 확인하세요.")
+                    .font(.caption2)
+                    .foregroundColor(.gray500)
+                    .opacity(store(\.hasChevronButtonTapped) ? 1.0 : 0.0)
+            }
+            
+            Button {
+                store.onChevronButtonTapped()
+            } label: {
+                Image(systemName: "chevron.compact.up")
+                    .resizable()
+                    .frame(width: 32, height: 10)
+                    .foregroundColor(.gray400)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, 10)
+        .background {
+            Color.white.opacity(0.3)
+        }
+    }
+    
+    private var hasQuestionTextReachedMaximumCount: Bool {
+        store(\.questionText).count == store.questionTextLimit
+    }
+}
+
+// MARK: Recording Component Container
+extension TKCommunicationView {
+    private func guideMessageBuilder() -> some View {
+        Text(Constants.GUIDE_MESSAGE)
+            .font(.title)
+            .bold()
+            .multilineTextAlignment(.leading)
+            .lineSpacing(12)
+            .foregroundColor(.gray)
+    }
+    
+    private func stopRecordButtonBuilder() -> some View {
+        Button {
+            store.onStopRecordingButtonTapped()
+            
+        } label: {
+            Image(systemName: "square.fill")
+                .foregroundColor(.white)
+                .padding()
+                .background {
+                    Circle()
+                        .foregroundColor(.gray)
+                }
+        }
     }
 }
 
 
-
+struct TKIntroView_Previews: PreviewProvider {
+    static var previews: some View {
+        TKCommunicationView()
+    }
+}

--- a/talklat/talklat/Sources/Views/TKCommunicationView.swift
+++ b/talklat/talklat/Sources/Views/TKCommunicationView.swift
@@ -5,13 +5,10 @@
 //  Created by Celan on 2023/10/05.
 //
 
-// TODO: 애초부터 하나의 뷰 내에서 Component만 변화하고 있으니 View를 이렇게 분리할 필요가 없다고 본다
-// 괜히 뷰 쪼개서 Animation, Transition 복잡하게 하지 말고 하던대로 해보자
 import SwiftUI
 
-struct TKIntroView: View {
-    @Environment(\.scenePhase)
-    var scenePhase
+struct TKCommunicationView: View {
+    @Environment(\.scenePhase) private var scenePhase
     @StateObject var gyroMotionStore: GyroScopeStore = GyroScopeStore()
     @ObservedObject var appViewStore: AppViewStore
     
@@ -57,7 +54,7 @@ struct TKIntroView: View {
 
 struct TKIntroView_Previews: PreviewProvider {
     static var previews: some View {
-        TKIntroView(
+        TKCommunicationView(
             appViewStore: .makePreviewStore(condition: { store in
                 store.questionTextSetter("")
                 store.voiceRecordingAuthSetter(.authCompleted)

--- a/talklat/talklat/talklatApp.swift
+++ b/talklat/talklat/talklatApp.swift
@@ -14,12 +14,9 @@ struct talklatApp: App {
         questionText: "",
         currentAuthStatus: .authIncompleted
     )
+    @State private var animateFlagA: Bool = false
     
     private let appRootManager = AppRootManager()
-    
-    @State private var animateFlagA: Bool = false
-    @State private var animateFlagB: Bool = false
-    @State private var isInitCompleted: Bool = false
     
     var body: some Scene {
         WindowGroup {
@@ -37,9 +34,7 @@ struct talklatApp: App {
                         }
                     
                 case .authCompleted:
-                    NavigationStack {
-                        TKIntroView(appViewStore: appViewStore)
-                    }
+                    TKCommunicationView()
                     
                 case .speechRecognitionAuthIncompleted
                     ,.microphoneAuthIncompleted


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->
<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `TKCommunicationView 구현` | 
| :--- | :--- |
| 📜 **Description** | TKCommunicationView와 midfi animation을 구현합니다. |
| 📌 **Issue Number** | #63 |
| ![](https://img.shields.io/badge/-black?logo=figma)**Figma** | [Mid-Fi 🤔 모코☕️👃](https://www.figma.com/file/Mb450yYTvio6Q9y6d0otwv/%F0%9F%8D%8EALLWAY-Team?type=design&node-id=1113-2943&mode=design) |
| ![](https://img.shields.io/badge/-black?logo=notion)**Notion Card** | _ |

---

## 작업 사항
<!-- 1. MainIntroView의 ScrollView 구현 -->
1. `TKCommunicationView` 를 구현했습니다.
  - Animation과 Transition이 적용되었으나, Animation Delay가 있는 것으로 확인됩니다.
  - 추후 수정 예정!
2. `AppViewStore` 의 역할이 커지면서, `TKCommunicationViewStore`를 분리했습니다.
  - `TKCommunicationView` 의 `State`를 관리 및 처리합니다.
  - 외부에서의 접근에 대해 캡슐화된 객체로 구현되었습니다.

## `Logics`
## `KVC(Key-Value Coding)`와 `KeyPath` 타입
- `KVC`는 objc 가 제공하는 기술 중 하나이며, `NSObject` 를 따르는 클래스 타입이 `NSKeyValueCoding`를 채택할 때 사용할 수 있습니다.
- 특정 객체 속성에 직접 접근하는 것이 아니라 문자열로 된 key를 입력하여 속성에 간접 접근합니다.
```objc
// gameObject의 weapon 속성에 접근하여 `arrow`를 가져오는 예시
id arrow = [gameObject valueForKeyPath:@"weapon"];
```

- Swift에서도 위와 같은 방식을 활용할 수 있지만 문자열로 key를 지정하는 방식에서 벗어나 타입의 속성으로 경로를 지정할 수 있게 하는 'KeyPath' 타입이 [Swift 5.2 이후 버전](https://github.com/apple/swift/blob/main/CHANGELOG.md)에 도입되었습니다.
- 특정 타입의 객체에 접근하여 그 내부의 속성을 가져오는 '경로'를 설정할 수 있습니다.

```swift
struct MyStruct {
  private var name: String = "name"
  
  // KeyPath의 타입 파라미터(제너릭)에는 
  // '접근할 타입' 그리고 그 타입에서 '접근할 속성의 타입'을 전달합니다.
  // CommunicationViewStore 에서 자세히 설명합니다.
  func getValues(_ keyPath: KeyPath<Self, String>) -> String {
    switch keyPath {
      case \.name: return self[keyPath: keyPath]
      default: return ""
    }
  }
}
```

## `private`한 방식의 `Store`를 구현하는 방법에 대한 고민
> 대부분의 아이디어는 The Composable Architecture에서 차용했습니다.

### [개선 목표]
- `View`는 자기 자신을 렌더링할 떄 필요한 값, 즉 `State`를 참조하기만 하며, 그 어떤 mutation에도 관여하지 않는다.
- Mutation을 일으키는 Action을 `Store`가 **단일한 메소드**로 처리한다(객체의 공간 복잡도 개선을 위해).
- 협업자가 알아보기 쉽고 사용하기 쉬운 코드를 작성한다.
- 세로든, 가로든 길어지지 않는 형태로 코드의 공간 복잡도를 줄이고 개선한다.

### [기존]
- 기존에는 `@Published`를 각각의 속성이 갖고, 해당 속성을 `View`에서 직접 호출할 수 있었음
- `private(set)`을 선언하지 않으면 외부에서의 mutation에 취약하게 노출됨
- `private(set)`을 사용하면 각 속성에 대한 mutation 메소드를 각각 구현해야 하는 번거로움이 존재했음
- 너무 많은 내부 메소드의 존재로 객체의 코드 복잡도가 높아짐

### [해결]
```swift
final class CommunicationViewStore: ObservableObject {
  struct CommunicationState: Equatable {
      // 서로 다른 타입의 여러 State 속성들
  }
  
  // ✅ View가 참조하는 유일하고 private한 @Published 속성
  @Published private var viewState: CommunicationState

  // 서로 다른 타입의 속성에 대응하기 위한 제너릭 파라미터 활용
  // KeyPath로 불러오는 타입과 새로 업데이트할 속성의 타입을 일치시켜, 호출 시점에 타입 추론 가능
  // ✅ 직접 update 하는 로직도 캡슐화하여 객체 외부에서의 mutation 사전 차단
  // ✅ 속성을 case로 제공하는 KeyPath의 도움으로, 각 속성에 대한 mutation 메소드 단일화 성공
  private func updateState<Value: Equatable>(
    _ state: WritableKeyPath<CommunicationState, Value>,
    with newValue: Value
  ) {
    switch state {
    case \.historyItem:
      self.viewState[keyPath: state] = newValue
      if let newHistoryItem = self.viewState.historyItem {
        self.viewState.historyItems.append(newHistoryItem)
      }
    case \.hasGuidingMessageShown:
      withAnimation {
        self.viewState[keyPath: state] = newValue
      }
      
    case \.historyItems:
      break
        
    default:
      self.viewState[keyPath: state] = newValue
    }
  }
  
  // 각 ViewState의 속성을 CommunicationStore의 인스턴스에서 KeyPath 접근할 수 있도록
  // CommunicationStore에서 ViewState에 접근할 수 있는 callAsFunction으로 대응
  // ✅ store.viewState.myProperty 처럼 길어지는 코드를 store(\.myProperty)로 축약하여 편리한 사용 가능
  public func callAsFunction<Value: Equatable>
  (_ keyPath: KeyPath<CommunicationState, Value>) -> Value {
    self.viewState[keyPath: keyPath]
  }
}

/// 호출부
struct ExampleView: View {
  @StateObject private var store: CommunicationViewStore = CommunicationViewStore()

  var body: some View {
    // CommunicationViewStore 타입의 callAsFunction이 KeyPath 경로에 저장된 myText 속성을 참조한다.
    Text(store(\.myText))
      .onAppear {
        // View는 그 mutation에 관여하지 않고, 유저 액션에 대한 반응을 Store로 보낸다.
        store.onViewAppear() 
      }
  }
}

```

---

## 작업 결과
<!-- 이미지, gif 등을 캡쳐하여 첨부합니다. -->
<!-- 해당 섹션은 필수가 아닙니다! -->
| GIF |
| --- |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/3a9d2480-2b08-4ba6-9e82-2ec8142fd310" width="250"> |

---

#### 기타 공유사항
<!-- 야기될 수 있는 사이드 이펙트, 조사가 필요한 내용 등을 작성합니다. --> 
1. 실기기에서 작동할 때, 왜인지 모르게 Animation에 극심한 딜레이가 발생합니다..
  - 버그 픽스 예정입니다.. 흑흑
2. TKCommunicationView는 추후 TKIntroView를 완전히 대체할 예정입니다. 또한 CommunicationViewStore가 AppViewStore의 로직들을 이관할 예정입니다. 
  - cc.  @lianne-b, @MADElinessss