### PR TITLE
Feat/#83 Base Widget 구현

### DIFF
--- a/talklat/talklat.xcodeproj/project.pbxproj
+++ b/talklat/talklat.xcodeproj/project.pbxproj
@@ -19,6 +19,14 @@
 		7E8D17D62ACE8AED00E904E5 /* talklatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17D52ACE8AED00E904E5 /* talklatTests.swift */; };
 		7E8D17E02ACE8AED00E904E5 /* talklatUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17DF2ACE8AED00E904E5 /* talklatUITests.swift */; };
 		7E8D17E22ACE8AED00E904E5 /* talklatUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17E12ACE8AED00E904E5 /* talklatUITestsLaunchTests.swift */; };
+		7E9FEF552AF8CEAD000C4D49 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E9FEF542AF8CEAD000C4D49 /* WidgetKit.framework */; };
+		7E9FEF572AF8CEAD000C4D49 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E9FEF562AF8CEAD000C4D49 /* SwiftUI.framework */; };
+		7E9FEF5A2AF8CEAD000C4D49 /* talklatWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9FEF592AF8CEAD000C4D49 /* talklatWidgetBundle.swift */; };
+		7E9FEF5C2AF8CEAD000C4D49 /* talklatWidgetLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9FEF5B2AF8CEAD000C4D49 /* talklatWidgetLiveActivity.swift */; };
+		7E9FEF5E2AF8CEAD000C4D49 /* talklatWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9FEF5D2AF8CEAD000C4D49 /* talklatWidget.swift */; };
+		7E9FEF602AF8CEAD000C4D49 /* AppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9FEF5F2AF8CEAD000C4D49 /* AppIntent.swift */; };
+		7E9FEF622AF8CEAE000C4D49 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E9FEF612AF8CEAE000C4D49 /* Assets.xcassets */; };
+		7E9FEF672AF8CEAE000C4D49 /* talklatWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 7E9FEF522AF8CEAD000C4D49 /* talklatWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		7EA8A78B2AD502D600AFD687 /* GyroScopeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA8A78A2AD502D600AFD687 /* GyroScopeStore.swift */; };
 		7ED9AA082ACE8E4300B1EA4E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E8D17CB2ACE8AED00E904E5 /* Preview Assets.xcassets */; };
 		7ED9AA092ACE8E4300B1EA4E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E8D17C82ACE8AED00E904E5 /* Assets.xcassets */; };
@@ -56,7 +64,28 @@
 			remoteGlobalIDString = 7E8D17C02ACE8AEC00E904E5;
 			remoteInfo = talklat;
 		};
+		7E9FEF642AF8CEAE000C4D49 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7E8D17B92ACE8AEC00E904E5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E9FEF512AF8CEAD000C4D49;
+			remoteInfo = talklatWidgetExtension;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		7E9FEF662AF8CEAE000C4D49 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				7E9FEF672AF8CEAE000C4D49 /* talklatWidgetExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		575677E02ADA6F13002E01BE /* TLTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TLTextField.swift; sourceTree = "<group>"; };
@@ -76,6 +105,17 @@
 		7E8D17DB2ACE8AED00E904E5 /* talklatUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = talklatUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E8D17DF2ACE8AED00E904E5 /* talklatUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = talklatUITests.swift; sourceTree = "<group>"; };
 		7E8D17E12ACE8AED00E904E5 /* talklatUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = talklatUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		7E9FEF522AF8CEAD000C4D49 /* talklatWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = talklatWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		7E9FEF542AF8CEAD000C4D49 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		7E9FEF562AF8CEAD000C4D49 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		7E9FEF592AF8CEAD000C4D49 /* talklatWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = talklatWidgetBundle.swift; sourceTree = "<group>"; };
+		7E9FEF5B2AF8CEAD000C4D49 /* talklatWidgetLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = talklatWidgetLiveActivity.swift; sourceTree = "<group>"; };
+		7E9FEF5D2AF8CEAD000C4D49 /* talklatWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = talklatWidget.swift; sourceTree = "<group>"; };
+		7E9FEF5F2AF8CEAD000C4D49 /* AppIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntent.swift; sourceTree = "<group>"; };
+		7E9FEF612AF8CEAE000C4D49 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		7E9FEF632AF8CEAE000C4D49 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7E9FEF6C2AF8D93D000C4D49 /* talklat.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = talklat.entitlements; sourceTree = "<group>"; };
+		7E9FEF6D2AF8D95C000C4D49 /* talklatWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = talklatWidgetExtension.entitlements; sourceTree = "<group>"; };
 		7EA8A78A2AD502D600AFD687 /* GyroScopeStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GyroScopeStore.swift; sourceTree = "<group>"; };
 		7EE087E72ADD4FAE00E07720 /* TKHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKHistoryView.swift; sourceTree = "<group>"; };
 		7EE71BAE2AF0F28E001C0A28 /* TKTransitionTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKTransitionTestView.swift; sourceTree = "<group>"; };
@@ -118,6 +158,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7E9FEF4F2AF8CEAD000C4D49 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7E9FEF572AF8CEAD000C4D49 /* SwiftUI.framework in Frameworks */,
+				7E9FEF552AF8CEAD000C4D49 /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -132,9 +181,12 @@
 		7E8D17B82ACE8AEC00E904E5 = {
 			isa = PBXGroup;
 			children = (
+				7E9FEF6D2AF8D95C000C4D49 /* talklatWidgetExtension.entitlements */,
 				7E8D17C32ACE8AEC00E904E5 /* talklat */,
+				7E9FEF582AF8CEAD000C4D49 /* talklatWidget */,
 				7E8D17D42ACE8AED00E904E5 /* talklatTests */,
 				7E8D17DE2ACE8AED00E904E5 /* talklatUITests */,
+				7E9FEF532AF8CEAD000C4D49 /* Frameworks */,
 				7E8D17C22ACE8AEC00E904E5 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -145,6 +197,7 @@
 				7E8D17C12ACE8AEC00E904E5 /* talklat.app */,
 				7E8D17D12ACE8AED00E904E5 /* talklatTests.xctest */,
 				7E8D17DB2ACE8AED00E904E5 /* talklatUITests.xctest */,
+				7E9FEF522AF8CEAD000C4D49 /* talklatWidgetExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -152,6 +205,7 @@
 		7E8D17C32ACE8AEC00E904E5 /* talklat */ = {
 			isa = PBXGroup;
 			children = (
+				7E9FEF6C2AF8D93D000C4D49 /* talklat.entitlements */,
 				7E8D17C42ACE8AEC00E904E5 /* talklatApp.swift */,
 				7E8D17EF2ACE8B8900E904E5 /* Sources */,
 				7E8D17EE2ACE8B1400E904E5 /* Resources */,
@@ -219,6 +273,36 @@
 				7EE087E72ADD4FAE00E07720 /* TKHistoryView.swift */,
 				57806D702ADC5D19003A7B19 /* TestHistoryView.swift */,
 				EFA9EDA32AF3D6E60099AB56 /* ScrollOffsetObserver.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		7E9FEF532AF8CEAD000C4D49 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				7E9FEF542AF8CEAD000C4D49 /* WidgetKit.framework */,
+				7E9FEF562AF8CEAD000C4D49 /* SwiftUI.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		7E9FEF582AF8CEAD000C4D49 /* talklatWidget */ = {
+			isa = PBXGroup;
+			children = (
+				7E9FEF6B2AF8D3FE000C4D49 /* Views */,
+				7E9FEF592AF8CEAD000C4D49 /* talklatWidgetBundle.swift */,
+				7E9FEF5B2AF8CEAD000C4D49 /* talklatWidgetLiveActivity.swift */,
+				7E9FEF5D2AF8CEAD000C4D49 /* talklatWidget.swift */,
+				7E9FEF5F2AF8CEAD000C4D49 /* AppIntent.swift */,
+				7E9FEF612AF8CEAE000C4D49 /* Assets.xcassets */,
+				7E9FEF632AF8CEAE000C4D49 /* Info.plist */,
+			);
+			path = talklatWidget;
+			sourceTree = "<group>";
+		};
+		7E9FEF6B2AF8D3FE000C4D49 /* Views */ = {
+			isa = PBXGroup;
+			children = (
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -292,10 +376,12 @@
 				7E8D17BD2ACE8AEC00E904E5 /* Sources */,
 				7E8D17BE2ACE8AEC00E904E5 /* Frameworks */,
 				7E8D17BF2ACE8AEC00E904E5 /* Resources */,
+				7E9FEF662AF8CEAE000C4D49 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				7E9FEF652AF8CEAE000C4D49 /* PBXTargetDependency */,
 			);
 			name = talklat;
 			productName = talklat;
@@ -338,6 +424,23 @@
 			productReference = 7E8D17DB2ACE8AED00E904E5 /* talklatUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		7E9FEF512AF8CEAD000C4D49 /* talklatWidgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7E9FEF6A2AF8CEAE000C4D49 /* Build configuration list for PBXNativeTarget "talklatWidgetExtension" */;
+			buildPhases = (
+				7E9FEF4E2AF8CEAD000C4D49 /* Sources */,
+				7E9FEF4F2AF8CEAD000C4D49 /* Frameworks */,
+				7E9FEF502AF8CEAD000C4D49 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = talklatWidgetExtension;
+			productName = talklatWidgetExtension;
+			productReference = 7E9FEF522AF8CEAD000C4D49 /* talklatWidgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -345,7 +448,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1420;
+				LastSwiftUpdateCheck = 1500;
 				LastUpgradeCheck = 1500;
 				TargetAttributes = {
 					7E8D17C02ACE8AEC00E904E5 = {
@@ -358,6 +461,9 @@
 					7E8D17DA2ACE8AED00E904E5 = {
 						CreatedOnToolsVersion = 14.2;
 						TestTargetID = 7E8D17C02ACE8AEC00E904E5;
+					};
+					7E9FEF512AF8CEAD000C4D49 = {
+						CreatedOnToolsVersion = 15.0.1;
 					};
 				};
 			};
@@ -375,6 +481,7 @@
 			projectRoot = "";
 			targets = (
 				7E8D17C02ACE8AEC00E904E5 /* talklat */,
+				7E9FEF512AF8CEAD000C4D49 /* talklatWidgetExtension */,
 				7E8D17D02ACE8AED00E904E5 /* talklatTests */,
 				7E8D17DA2ACE8AED00E904E5 /* talklatUITests */,
 			);
@@ -402,6 +509,14 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7E9FEF502AF8CEAD000C4D49 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7E9FEF622AF8CEAE000C4D49 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -459,6 +574,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7E9FEF4E2AF8CEAD000C4D49 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7E9FEF5C2AF8CEAD000C4D49 /* talklatWidgetLiveActivity.swift in Sources */,
+				7E9FEF602AF8CEAD000C4D49 /* AppIntent.swift in Sources */,
+				7E9FEF5A2AF8CEAD000C4D49 /* talklatWidgetBundle.swift in Sources */,
+				7E9FEF5E2AF8CEAD000C4D49 /* talklatWidget.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -471,6 +597,11 @@
 			isa = PBXTargetDependency;
 			target = 7E8D17C02ACE8AEC00E904E5 /* talklat */;
 			targetProxy = 7E8D17DC2ACE8AED00E904E5 /* PBXContainerItemProxy */;
+		};
+		7E9FEF652AF8CEAE000C4D49 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7E9FEF512AF8CEAD000C4D49 /* talklatWidgetExtension */;
+			targetProxy = 7E9FEF642AF8CEAE000C4D49 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -596,8 +727,10 @@
 		7E8D17E62ACE8AED00E904E5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = talklat/talklat.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"talklat/Resources/Preview Content\"";
@@ -632,8 +765,10 @@
 		7E8D17E72ACE8AED00E904E5 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = talklat/talklat.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"talklat/Resources/Preview Content\"";
@@ -741,6 +876,75 @@
 			};
 			name = Release;
 		};
+		7E9FEF682AF8CEAE000C4D49 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = talklatWidgetExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 67M6ZS7KS6;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = talklatWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = talklatWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.allway.talklat.talklatWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		7E9FEF692AF8CEAE000C4D49 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = talklatWidgetExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 67M6ZS7KS6;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = talklatWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = talklatWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.allway.talklat.talklatWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -776,6 +980,15 @@
 			buildConfigurations = (
 				7E8D17EC2ACE8AED00E904E5 /* Debug */,
 				7E8D17ED2ACE8AED00E904E5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7E9FEF6A2AF8CEAE000C4D49 /* Build configuration list for PBXNativeTarget "talklatWidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7E9FEF682AF8CEAE000C4D49 /* Debug */,
+				7E9FEF692AF8CEAE000C4D49 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/talklat/talklat/talklat.entitlements
+++ b/talklat/talklat/talklat.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array/>
+</dict>
+</plist>

--- a/talklat/talklat/talklat.entitlements
+++ b/talklat/talklat/talklat.entitlements
@@ -3,6 +3,8 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.application-groups</key>
-	<array/>
+	<array>
+		<string>group.talklat</string>
+	</array>
 </dict>
 </plist>

--- a/talklat/talklatWidget/AppIntent.swift
+++ b/talklat/talklatWidget/AppIntent.swift
@@ -1,0 +1,18 @@
+//
+//  AppIntent.swift
+//  talklatWidget
+//
+//  Created by Celan on 11/6/23.
+//
+
+import WidgetKit
+import AppIntents
+
+struct ConfigurationAppIntent: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource = "Configuration"
+    static var description = IntentDescription("This is an example widget.")
+
+    // An example configurable parameter.
+    @Parameter(title: "Favorite Emoji", default: "😃")
+    var favoriteEmoji: String
+}

--- a/talklat/talklatWidget/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/talklat/talklatWidget/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x38",
+          "green" : "0x68",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklatWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/talklat/talklatWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklatWidget/Assets.xcassets/Contents.json
+++ b/talklat/talklatWidget/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklatWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/talklat/talklatWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklatWidget/Info.plist
+++ b/talklat/talklatWidget/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/talklat/talklatWidget/talklatWidget.swift
+++ b/talklat/talklatWidget/talklatWidget.swift
@@ -9,6 +9,11 @@ import WidgetKit
 import SwiftUI
 
 struct Provider: AppIntentTimelineProvider {
+    struct SimpleEntry: TimelineEntry {
+        let date: Date
+        let configuration: ConfigurationAppIntent
+    }
+    
     func placeholder(in context: Context) -> SimpleEntry {
         SimpleEntry(date: Date(), configuration: ConfigurationAppIntent())
     }
@@ -18,67 +23,64 @@ struct Provider: AppIntentTimelineProvider {
     }
     
     func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<SimpleEntry> {
-        var entries: [SimpleEntry] = []
-
-        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
-        let currentDate = Date()
-        for hourOffset in 0 ..< 5 {
-            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
-            let entry = SimpleEntry(date: entryDate, configuration: configuration)
-            entries.append(entry)
-        }
-
+        let entries: [SimpleEntry] = []
         return Timeline(entries: entries, policy: .atEnd)
     }
 }
 
-struct SimpleEntry: TimelineEntry {
-    let date: Date
-    let configuration: ConfigurationAppIntent
-}
-
-struct talklatWidgetEntryView : View {
-    var entry: Provider.Entry
-
+struct talklatWidgetSystemSmallView: View {
     var body: some View {
         VStack {
-            Text("Time:")
-            Text(entry.date, style: .time)
-
-            Text("Favorite Emoji:")
-            Text(entry.configuration.favoriteEmoji)
+            Text("TALKLAT")
+                .bold()
+            
+            Text("새 대화 시작")
+                .font(.caption)
+                .bold()
         }
-    }
-}
-
-struct talklatWidget: Widget {
-    let kind: String = "talklatWidget"
-
-    var body: some WidgetConfiguration {
-        AppIntentConfiguration(kind: kind, intent: ConfigurationAppIntent.self, provider: Provider()) { entry in
-            talklatWidgetEntryView(entry: entry)
-                .containerBackground(.fill.tertiary, for: .widget)
+        .unredacted()
+        .frame(
+            maxWidth: .infinity,
+            maxHeight: .infinity
+        )
+        .background {
+            Circle()
+                .foregroundStyle(.accent)
+                .padding()
+                .shadow(radius: 10)
         }
-    }
-}
-
-extension ConfigurationAppIntent {
-    fileprivate static var smiley: ConfigurationAppIntent {
-        let intent = ConfigurationAppIntent()
-        intent.favoriteEmoji = "😀"
-        return intent
-    }
-    
-    fileprivate static var starEyes: ConfigurationAppIntent {
-        let intent = ConfigurationAppIntent()
-        intent.favoriteEmoji = "🤩"
-        return intent
+        .background {
+            Circle()
+                .foregroundStyle(.accent.opacity(0.7))
+                .offset(x: 30, y: 30)
+        }
+        .background {
+            Circle()
+                .foregroundStyle(Color.red)
+                .offset(x: 30, y: 30)
+        }
+        .background {
+            Circle()
+                .foregroundStyle(.accent.opacity(0.5))
+                .offset(x: -24, y: -24)
+        }
+        .background {
+            Circle()
+                .frame(width: 100, height: 100)
+                .foregroundStyle(.accent.opacity(0.5))
+                .offset(x: 40, y: -48)
+        }
+        .background {
+            Circle()
+                .frame(width: 100, height: 100)
+                .foregroundStyle(.accent.opacity(0.9))
+                .offset(x: -40, y: 48)
+        }
     }
 }
 
 #Preview(as: .systemSmall) {
-    talklatWidget()
+    TalklatWidgetSystemSmall()
 } timeline: {
-    SimpleEntry(date: .now, configuration: .smiley)
-    SimpleEntry(date: .now, configuration: .starEyes)
+    Provider.SimpleEntry(date: .now, configuration: ConfigurationAppIntent())
 }

--- a/talklat/talklatWidget/talklatWidget.swift
+++ b/talklat/talklatWidget/talklatWidget.swift
@@ -1,0 +1,84 @@
+//
+//  talklatWidget.swift
+//  talklatWidget
+//
+//  Created by Celan on 11/6/23.
+//
+
+import WidgetKit
+import SwiftUI
+
+struct Provider: AppIntentTimelineProvider {
+    func placeholder(in context: Context) -> SimpleEntry {
+        SimpleEntry(date: Date(), configuration: ConfigurationAppIntent())
+    }
+
+    func snapshot(for configuration: ConfigurationAppIntent, in context: Context) async -> SimpleEntry {
+        SimpleEntry(date: Date(), configuration: configuration)
+    }
+    
+    func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<SimpleEntry> {
+        var entries: [SimpleEntry] = []
+
+        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
+        let currentDate = Date()
+        for hourOffset in 0 ..< 5 {
+            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
+            let entry = SimpleEntry(date: entryDate, configuration: configuration)
+            entries.append(entry)
+        }
+
+        return Timeline(entries: entries, policy: .atEnd)
+    }
+}
+
+struct SimpleEntry: TimelineEntry {
+    let date: Date
+    let configuration: ConfigurationAppIntent
+}
+
+struct talklatWidgetEntryView : View {
+    var entry: Provider.Entry
+
+    var body: some View {
+        VStack {
+            Text("Time:")
+            Text(entry.date, style: .time)
+
+            Text("Favorite Emoji:")
+            Text(entry.configuration.favoriteEmoji)
+        }
+    }
+}
+
+struct talklatWidget: Widget {
+    let kind: String = "talklatWidget"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(kind: kind, intent: ConfigurationAppIntent.self, provider: Provider()) { entry in
+            talklatWidgetEntryView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+    }
+}
+
+extension ConfigurationAppIntent {
+    fileprivate static var smiley: ConfigurationAppIntent {
+        let intent = ConfigurationAppIntent()
+        intent.favoriteEmoji = "😀"
+        return intent
+    }
+    
+    fileprivate static var starEyes: ConfigurationAppIntent {
+        let intent = ConfigurationAppIntent()
+        intent.favoriteEmoji = "🤩"
+        return intent
+    }
+}
+
+#Preview(as: .systemSmall) {
+    talklatWidget()
+} timeline: {
+    SimpleEntry(date: .now, configuration: .smiley)
+    SimpleEntry(date: .now, configuration: .starEyes)
+}

--- a/talklat/talklatWidget/talklatWidgetBundle.swift
+++ b/talklat/talklatWidget/talklatWidgetBundle.swift
@@ -11,7 +11,27 @@ import SwiftUI
 @main
 struct talklatWidgetBundle: WidgetBundle {
     var body: some Widget {
-        talklatWidget()
-        talklatWidgetLiveActivity()
+        TalklatWidgetSystemSmall()
+    }
+}
+
+struct TalklatWidgetSystemSmall: Widget {
+    let kind: String = "Talklat: Easy Start!"
+    
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: kind,
+//            intent: ConfigurationAppIntent.self,
+            provider: Provider()
+        ) { _ in
+            talklatWidgetSystemSmallView()
+                .containerBackground(
+                    .fill.tertiary,
+                    for: .widget
+                )
+        }
+        .contentMarginsDisabled()
+        .configurationDisplayName("TALKLAT: 새 대화 시작하기")
+        .description("위젯을 배치해서 다른 사람과 바로 대화를 시작해 볼까요?")
     }
 }

--- a/talklat/talklatWidget/talklatWidgetBundle.swift
+++ b/talklat/talklatWidget/talklatWidgetBundle.swift
@@ -1,0 +1,17 @@
+//
+//  talklatWidgetBundle.swift
+//  talklatWidget
+//
+//  Created by Celan on 11/6/23.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct talklatWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        talklatWidget()
+        talklatWidgetLiveActivity()
+    }
+}

--- a/talklat/talklatWidget/talklatWidgetLiveActivity.swift
+++ b/talklat/talklatWidget/talklatWidgetLiveActivity.swift
@@ -1,0 +1,80 @@
+//
+//  talklatWidgetLiveActivity.swift
+//  talklatWidget
+//
+//  Created by Celan on 11/6/23.
+//
+
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+struct talklatWidgetAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        // Dynamic stateful properties about your activity go here!
+        var emoji: String
+    }
+
+    // Fixed non-changing properties about your activity go here!
+    var name: String
+}
+
+struct talklatWidgetLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: talklatWidgetAttributes.self) { context in
+            // Lock screen/banner UI goes here
+            VStack {
+                Text("Hello \(context.state.emoji)")
+            }
+            .activityBackgroundTint(Color.cyan)
+            .activitySystemActionForegroundColor(Color.black)
+
+        } dynamicIsland: { context in
+            DynamicIsland {
+                // Expanded UI goes here.  Compose the expanded UI through
+                // various regions, like leading/trailing/center/bottom
+                DynamicIslandExpandedRegion(.leading) {
+                    Text("Leading")
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text("Trailing")
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text("Bottom \(context.state.emoji)")
+                    // more content
+                }
+            } compactLeading: {
+                Text("L")
+            } compactTrailing: {
+                Text("T \(context.state.emoji)")
+            } minimal: {
+                Text(context.state.emoji)
+            }
+            .widgetURL(URL(string: "http://www.apple.com"))
+            .keylineTint(Color.red)
+        }
+    }
+}
+
+extension talklatWidgetAttributes {
+    fileprivate static var preview: talklatWidgetAttributes {
+        talklatWidgetAttributes(name: "World")
+    }
+}
+
+extension talklatWidgetAttributes.ContentState {
+    fileprivate static var smiley: talklatWidgetAttributes.ContentState {
+        talklatWidgetAttributes.ContentState(emoji: "😀")
+     }
+     
+     fileprivate static var starEyes: talklatWidgetAttributes.ContentState {
+         talklatWidgetAttributes.ContentState(emoji: "🤩")
+     }
+}
+
+#Preview("Notification", as: .content, using: talklatWidgetAttributes.preview) {
+   talklatWidgetLiveActivity()
+} contentStates: {
+    talklatWidgetAttributes.ContentState.smiley
+    talklatWidgetAttributes.ContentState.starEyes
+}

--- a/talklat/talklatWidgetExtension.entitlements
+++ b/talklat/talklatWidgetExtension.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/talklat/talklatWidgetExtension.entitlements
+++ b/talklat/talklatWidgetExtension.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.talklat</string>
+	</array>
+</dict>
 </plist>


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->

<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `Base Widget 구현` | 
| :--- | :--- |
| 📜 **Description** | Base Widget을 구현합니다. |
| 📌 **Issue Number** | #83 |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/a42c6a40-0f1d-4372-9c9c-967d44803665" width='20'> **Figma** | [미구현] |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/c7f9920d-e975-4ed7-ad83-7e6e08611463" width='20'> **Notion** | _ |

---

## 작업 사항
<!-- 1. MainIntroView의 ScrollView 구현 -->
1. Base Widget을 간단히 구현합니다.
  - Widget을 탭 할 때, ConversationView로 랜딩합니다.
  - Widget의 Description과 title을 간단히 정리하여 보여줍니다.

---

## 작업 결과
<!-- 이미지, gif 등을 캡쳐하여 첨부합니다. -->
<!-- 해당 섹션은 필수가 아닙니다! -->
![talklat_widget](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/4515f443-aa27-4814-bee6-6d87b9ce41bd)

---

#### 기타 공유사항
<!-- 야기될 수 있는 사이드 이펙트, 조사가 필요한 내용 등을 작성합니다. --> 
1. App Groups 에서 위젯에서 랜딩할 때의 딥링크를 따로 진행할 예정입니다.
2. SwiftData의 작업이 마무리되면 Widget과 Application이 동시에 같은 데이터를 참조하도록 개선합니다.