### PR TITLE
Feat/#90 TKReducer lmpl

### DIFF
--- a/talklat/talklat.xcodeproj/project.pbxproj
+++ b/talklat/talklat.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		7E8D17E02ACE8AED00E904E5 /* talklatUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17DF2ACE8AED00E904E5 /* talklatUITests.swift */; };
 		7E8D17E22ACE8AED00E904E5 /* talklatUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17E12ACE8AED00E904E5 /* talklatUITestsLaunchTests.swift */; };
 		7EA8A78B2AD502D600AFD687 /* GyroScopeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA8A78A2AD502D600AFD687 /* GyroScopeStore.swift */; };
+		7EA9D34D2AFA19BE00A0EE99 /* TKReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA9D34C2AFA19BE00A0EE99 /* TKReducer.swift */; };
 		7ED9AA082ACE8E4300B1EA4E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E8D17CB2ACE8AED00E904E5 /* Preview Assets.xcassets */; };
 		7ED9AA092ACE8E4300B1EA4E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E8D17C82ACE8AED00E904E5 /* Assets.xcassets */; };
 		7EE087E82ADD4FAE00E07720 /* TKHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE087E72ADD4FAE00E07720 /* TKHistoryView.swift */; };
@@ -77,6 +78,7 @@
 		7E8D17DF2ACE8AED00E904E5 /* talklatUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = talklatUITests.swift; sourceTree = "<group>"; };
 		7E8D17E12ACE8AED00E904E5 /* talklatUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = talklatUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		7EA8A78A2AD502D600AFD687 /* GyroScopeStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GyroScopeStore.swift; sourceTree = "<group>"; };
+		7EA9D34C2AFA19BE00A0EE99 /* TKReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKReducer.swift; sourceTree = "<group>"; };
 		7EE087E72ADD4FAE00E07720 /* TKHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKHistoryView.swift; sourceTree = "<group>"; };
 		7EE71BAE2AF0F28E001C0A28 /* TKTransitionTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKTransitionTestView.swift; sourceTree = "<group>"; };
 		7EF7378B2AD3C87700FCBA21 /* AppViewStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppViewStore.swift; sourceTree = "<group>"; };
@@ -196,6 +198,7 @@
 		7E8D17EF2ACE8B8900E904E5 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				7EE909BE2AFA6B6A0048AF77 /* Protocols */,
 				57806D7E2AE28E85003A7B19 /* Models */,
 				7EF737922AD3DE4C00FCBA21 /* Utilities */,
 				7EF7378D2AD3D23F00FCBA21 /* Stores */,
@@ -231,6 +234,14 @@
 				EFA9EDA12AF35CC40099AB56 /* TKGuidingView.swift */,
 			);
 			path = Conversation;
+			sourceTree = "<group>";
+		};
+		7EE909BE2AFA6B6A0048AF77 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				7EA9D34C2AFA19BE00A0EE99 /* TKReducer.swift */,
+			);
+			path = Protocols;
 			sourceTree = "<group>";
 		};
 		7EF7378D2AD3D23F00FCBA21 /* Stores */ = {
@@ -425,6 +436,7 @@
 				7EFA2C2B2AD51FC80013B533 /* Double+Degree.swift in Sources */,
 				EF90C51F2AE0B39B00A95BD7 /* ScrollContainer.swift in Sources */,
 				7E8445DE2ADFBBD900CFB8BC /* TKColor.swift in Sources */,
+				7EA9D34D2AFA19BE00A0EE99 /* TKReducer.swift in Sources */,
 				7EF737972AD43EE000FCBA21 /* TKTextField.swift in Sources */,
 				7E8445DA2ADFB4FC00CFB8BC /* Color+Hex.swift in Sources */,
 				EF67C6532AD13BF700C1074E /* AppRootManager.swift in Sources */,

--- a/talklat/talklat/Sources/Protocols/TKReducer.swift
+++ b/talklat/talklat/Sources/Protocols/TKReducer.swift
@@ -7,9 +7,10 @@
 
 import SwiftUI
 
-/// ObservableObject를 채택하는 프로토콜이다.
-/// 채택할 때, ViewState 타입인 구조체를 생성해야 하며
-/// State을 업데이트할 추가적인 로직이 불필요할 경우, ``reduce(_:into:)``의 구현을 생략할 수 있다.
+/// ObservableObject를 채택하는 TKReducer 프로토콜
+///
+/// ViewState 타입 구조체, ``reduce(_:into:)`` 구현을 요구
+/// store 역할을 수행할 class 타입에서 채택
 protocol TKReducer: ObservableObject, AnyObject {
     associatedtype ViewState
     
@@ -26,12 +27,6 @@ extension TKReducer {
     (_ path: KeyPath<ViewState, Value>) -> Value {
         self.callAsFunction(path)
     }
-    
-    func reduce<Value: Equatable>
-    (_ path: WritableKeyPath<ViewState, Value>,
-     into newValue: Value) {
-        self.reduce(path, into: newValue)
-    }
 }
 
 // MARK: - USAGE EXAMPLE
@@ -44,6 +39,13 @@ final class MyStore: TKReducer {
     
     func onUpdateName(with str: String) {
         reduce(\.name, into: str)
+    }
+    
+    func reduce<Value: Equatable>(
+        _ path: WritableKeyPath<ViewState, Value>,
+        into newValue: Value)
+    {
+        self.viewState[keyPath: path] = newValue
     }
 }
 

--- a/talklat/talklat/Sources/Protocols/TKReducer.swift
+++ b/talklat/talklat/Sources/Protocols/TKReducer.swift
@@ -7,10 +7,9 @@
 
 import SwiftUI
 
-/// ObservableObject를 채택하는 프로토콜
+/// ObservableObject를 채택하는 프로토콜이다.
 /// 채택할 때, ViewState 타입인 구조체를 생성해야 하며
-/// 해당 구조체를 reduce 할 로직을 직접 구현해야 한다.
-/// 추가 로직이 불필요할 경우, ``self[keyPath: path] = newValue`` 한 줄로 갈음할 수 있다.
+/// State을 업데이트할 추가적인 로직이 불필요할 경우, ``reduce(_:into:)``의 구현을 생략할 수 있다.
 protocol TKReducer: ObservableObject, AnyObject {
     associatedtype ViewState
     

--- a/talklat/talklat/Sources/Protocols/TKReducer.swift
+++ b/talklat/talklat/Sources/Protocols/TKReducer.swift
@@ -1,0 +1,61 @@
+//
+//  TKStateReducer.swift
+//  talklat
+//
+//  Created by Celan on 11/7/23.
+//
+
+import SwiftUI
+
+/// ObservableObject를 채택하는 프로토콜
+/// 채택할 때, ViewState 타입인 구조체를 생성해야 하며
+/// 해당 구조체를 reduce 할 로직을 직접 구현해야 한다.
+/// 추가 로직이 불필요할 경우, ``self[keyPath: path] = newValue`` 한 줄로 갈음할 수 있다.
+protocol TKReducer: ObservableObject, AnyObject {
+    associatedtype ViewState
+    
+    func callAsFunction<Value: Equatable>
+    (_ path: KeyPath<ViewState, Value>) -> Value
+    
+    func reduce<Value: Equatable>
+    (_ path: WritableKeyPath<ViewState, Value>,
+     into newValue: Value)
+}
+
+extension TKReducer {
+    func callAsFunction<Value: Equatable>
+    (_ path: KeyPath<ViewState, Value>) -> Value {
+        self.callAsFunction(path)
+    }
+    
+    func reduce<Value: Equatable>
+    (_ path: WritableKeyPath<ViewState, Value>,
+     into newValue: Value) {
+        self.reduce(path, into: newValue)
+    }
+}
+
+// MARK: - USAGE EXAMPLE
+final class MyStore: TKReducer {
+    struct ViewState {
+        var name: String = ""
+    }
+    
+    @Published private var viewState: ViewState = ViewState()
+    
+    func onUpdateName(with str: String) {
+        reduce(\.name, into: str)
+    }
+}
+
+struct MyStruct {
+    @StateObject private var store = MyStore()
+    
+    func getName() -> String {
+        store(\.name)
+    }
+    
+    func updateName() {
+        store.onUpdateName(with: "NewName")
+    }
+}

--- a/talklat/talklat/Sources/Stores/ConversationViewStore.swift
+++ b/talklat/talklat/Sources/Stores/ConversationViewStore.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-final class ConversationViewStore: ObservableObject {
+final class ConversationViewStore {
     enum ConversationStatus: Equatable {
         case recording
         case guiding
@@ -41,12 +41,6 @@ final class ConversationViewStore: ObservableObject {
     // MARK: init
     init(conversationState: ConversationState) {
         viewState = conversationState
-    }
-    
-    public func callAsFunction<Value: Equatable>(
-        _ keyPath: KeyPath<ConversationState, Value>
-    ) -> Value {
-        viewState[keyPath: keyPath]
     }
     
     // MARK: Helpers
@@ -178,31 +172,30 @@ final class ConversationViewStore: ObservableObject {
 }
 
 // MARK: Reduce
-extension ConversationViewStore {
+extension ConversationViewStore: TKReducer {
     /// ViewState를 업데이트하는 keyPath 기반 메소드
-    /// 일반적인 경우, default 만으로 대응이 가능하나, 특별한 로직이 필요할 경우 할당하는 로직을 케이스로 추가할 수 있다.
+    /// 일반적인 경우, protocol의 기본 구현으로 대응할 수 있다.
+    /// 특별한 로직이 필요할 경우 할당하는 로직을 케이스로 추가하기 위해 reduce를 직접 구현한다.
+    /// public 호출이 가능하다.
     /// - Parameters:
-    ///   - state: 업데이트할 ViewState의 속성 전달
+    ///   - state: 업데이트할 ViewState의 경로 전달
     ///   - newValue: 새로 업데이트할 ViweState의 값 전달
-    private func reduce<Value: Equatable>(
-        _ state: WritableKeyPath<ConversationState, Value>,
+    internal func reduce<Value: Equatable>(
+        _ path: WritableKeyPath<ConversationState, Value>,
         into newValue: Value
     ) {
-        switch state {
+        switch path {
         case \.historyItem:
-            self.viewState[keyPath: state] = newValue
+            self.viewState[keyPath: path] = newValue
             if let newHistoryItem = self.viewState.historyItem {
                 self.viewState.historyItems.append(newHistoryItem)
             }
-            
-        case \.hasGuidingMessageShown:
-            self.viewState[keyPath: state] = newValue
             
         case \.historyItems:
             break
             
         default:
-            self.viewState[keyPath: state] = newValue
+            self.viewState[keyPath: path] = newValue
         }
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->

<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `TKReducer lmpl` | 
| :--- | :--- |
| 📜 **Description** | TKReducer를 구현했습니다. |
| 📌 **Issue Number** | #90 |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/a42c6a40-0f1d-4372-9c9c-967d44803665" width='20'> **Figma** | _ |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/c7f9920d-e975-4ed7-ad83-7e6e08611463" width='20'> **Notion** | _ |

---

## 작업 사항
<!-- 1. MainIntroView의 ScrollView 구현 -->
1. `TKReducer` protocol을 구현합니다.
  - `callAsFunction()` 을 기본구현하여 보일러플레이트 제거
  - `ObservableObject`를 TKReducer가 채택하여, Store 채택 부분에서의 프로토콜 채택 복잡도 저하

### `TKReducer`
```swift
protocol TKReducer: ObservableObject, AnyObject {
  // TKReducer를 채택하는 모든 타입은 ViewState 타입을 가져야 합니다.
  // ViewState 타입 안에 View Rendering을 위한 속성들을 캡슐화 합니다.
  associatedtype ViewState
  
  func callAsFunction<Value: Equatable>
  (_ path: KeyPath<ViewState, Value>) -> Value
  
  func reduce<Value: Equatable>
  (_ path: WritableKeyPath<ViewState, Value>,
   into newValue: Value)
}

extension TKReducer {
  // store(\.속성) 접근이 가능하도록 기본 구현된 메소드입니다.
  func callAsFunction<Value: Equatable>
  (_ path: KeyPath<ViewState, Value>) -> Value {
    self.callAsFunction(path)
  }
}
```

---

#### 기타 공유사항
<!-- 야기될 수 있는 사이드 이펙트, 조사가 필요한 내용 등을 작성합니다. --> 
1. `reduce(_:into:)` 를 따로 구현해야 하는 이유는 각 객체마다 서로 상이한 할당 로직을 가질 수 있기 때문입니다!
2. 추후 모든 Store 가 이 프로토콜을 따르게 되면 일관된 코드 체계를 가져서 보기에 깔끔해질 것 같아요