### PR TITLE
Feat/#86 TKConversation CRUD 구현

### DIFF
--- a/talklat/talklat.xcodeproj/project.pbxproj
+++ b/talklat/talklat.xcodeproj/project.pbxproj
@@ -36,7 +36,7 @@
 		EF67C64B2ACEB67000C1074E /* SpeechRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF67C64A2ACEB67000C1074E /* SpeechRecognizer.swift */; };
 		EF67C6532AD13BF700C1074E /* AppRootManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF67C6522AD13BF700C1074E /* AppRootManager.swift */; };
 		EF67C6572AD1414300C1074E /* AuthorizationRequestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF67C6562AD1414300C1074E /* AuthorizationRequestView.swift */; };
-		EF7938792AF8A58B00402A4E /* HistoryViewStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF7938782AF8A58B00402A4E /* HistoryViewStore.swift */; };
+		EF7938792AF8A58B00402A4E /* ConversationDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF7938782AF8A58B00402A4E /* ConversationDataManager.swift */; };
 		EF8067502AF7ECF4004E8955 /* TKTextReplacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF80674F2AF7ECF4004E8955 /* TKTextReplacement.swift */; };
 		EF90C51F2AE0B39B00A95BD7 /* ScrollContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF90C51E2AE0B39B00A95BD7 /* ScrollContainer.swift */; };
 		EF90C5212AE0FE9E00A95BD7 /* SwipeGuideMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF90C5202AE0FE9E00A95BD7 /* SwipeGuideMessage.swift */; };
@@ -94,7 +94,7 @@
 		EF67C64A2ACEB67000C1074E /* SpeechRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognizer.swift; sourceTree = "<group>"; };
 		EF67C6522AD13BF700C1074E /* AppRootManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRootManager.swift; sourceTree = "<group>"; };
 		EF67C6562AD1414300C1074E /* AuthorizationRequestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationRequestView.swift; sourceTree = "<group>"; };
-		EF7938782AF8A58B00402A4E /* HistoryViewStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewStore.swift; sourceTree = "<group>"; };
+		EF7938782AF8A58B00402A4E /* ConversationDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationDataManager.swift; sourceTree = "<group>"; };
 		EF80674F2AF7ECF4004E8955 /* TKTextReplacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKTextReplacement.swift; sourceTree = "<group>"; };
 		EF90C51E2AE0B39B00A95BD7 /* ScrollContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollContainer.swift; sourceTree = "<group>"; };
 		EF90C5202AE0FE9E00A95BD7 /* SwipeGuideMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeGuideMessage.swift; sourceTree = "<group>"; };
@@ -247,7 +247,6 @@
 				7EF7378B2AD3C87700FCBA21 /* AppViewStore.swift */,
 				7E427EE02AE9559D0028E4F4 /* ConversationViewStore.swift */,
 				7EA8A78A2AD502D600AFD687 /* GyroScopeStore.swift */,
-				EF7938782AF8A58B00402A4E /* HistoryViewStore.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -284,6 +283,7 @@
 		EF67C6492ACEB65400C1074E /* Managers */ = {
 			isa = PBXGroup;
 			children = (
+				EF7938782AF8A58B00402A4E /* ConversationDataManager.swift */,
 				EF67C6522AD13BF700C1074E /* AppRootManager.swift */,
 				EF67C64A2ACEB67000C1074E /* SpeechRecognizer.swift */,
 				CEF43C472ADA97FF00DE02A9 /* HapticManager.swift */,
@@ -438,7 +438,7 @@
 				7E8445DE2ADFBBD900CFB8BC /* TKColor.swift in Sources */,
 				7EF737972AD43EE000FCBA21 /* TKTextField.swift in Sources */,
 				7E8445DA2ADFB4FC00CFB8BC /* Color+Hex.swift in Sources */,
-				EF7938792AF8A58B00402A4E /* HistoryViewStore.swift in Sources */,
+				EF7938792AF8A58B00402A4E /* ConversationDataManager.swift in Sources */,
 				EF67C6532AD13BF700C1074E /* AppRootManager.swift in Sources */,
 				57806D802AE28ED3003A7B19 /* HistoryItem.swift in Sources */,
 				7EFE53782AE6228300DF4D85 /* View+Keyboard.swift in Sources */,

--- a/talklat/talklat/Sources/Managers/ConversationDataManager.swift
+++ b/talklat/talklat/Sources/Managers/ConversationDataManager.swift
@@ -1,5 +1,5 @@
 //
-//  HistoryViewStore.swift
+//  ConversationDataManager.swift
 //  talklat
 //
 //  Created by Ye Eun Choi on 11/6/23.
@@ -8,7 +8,7 @@
 import SwiftData
 import SwiftUI
 
-final class HistoryViewStore: ObservableObject {
+final class ConversationDataManager: ObservableObject {
     @Environment(\.modelContext) private var context
     
     // MARK: - CREATE

--- a/talklat/talklat/Sources/Stores/HistoryViewStore.swift
+++ b/talklat/talklat/Sources/Stores/HistoryViewStore.swift
@@ -5,16 +5,63 @@
 //  Created by Ye Eun Choi on 11/6/23.
 //
 
-import Foundation
 import SwiftData
 import SwiftUI
 
 final class HistoryViewStore: ObservableObject {
     @Environment(\.modelContext) private var context
     
-    public func addConversation(_ conversation:TKConversation) {
+    // MARK: - CREATE
+    public func createConversation(_ conversation: TKConversation) {
         context.insert(conversation)
     }
+    
+    // MARK: - UPDATE
+    public func updateConversation(
+        oldItem: TKConversation,
+        newItem: TKConversation
+    ) {
+        oldItem.title = newItem.title
+        oldItem.createdAt = newItem.createdAt
+        oldItem.updatedAt = newItem.updatedAt
+        oldItem.content = newItem.content
+    }
+    
+    // MARK: - DELETE
+    public func deleteConversation(_ conversation: TKConversation) {
+        context.delete(conversation)
+    }
 }
+
+extension ModelContext {
+    // MARK: - FETCH
+    // Model ID와 일치하는 단일 인스턴스 반환
+    public func fetchMatchingObject<T>(
+        for objectID: PersistentIdentifier
+    ) throws -> T? where T: PersistentModel {
+        if let registered: T = registeredModel(for: objectID) {
+            return registered
+        }
+        
+        let fetchDescriptor = FetchDescriptor<T>(
+            predicate: #Predicate {
+                $0.persistentModelID == objectID
+            }
+        )
+        
+        return try fetch(fetchDescriptor).first
+    }
+    
+    // 해당 Model 타입의 모든 인스턴스 반환
+    public func fetchAllMatchingObjects<T>(
+        for object: T
+    ) throws -> [T]? where T: PersistentModel {
+        let fetchDescriptor = FetchDescriptor<T>()
+        
+        return try fetch(fetchDescriptor)
+    }
+}
+
+
 
 


### PR DESCRIPTION
## 개요 및 관련 이슈

| ⚒️ Title | `TKConversation 관련 SwiftData CRUD 구현` | 
| :--- | :--- |
| 📜 **Description** | TKConversation 관련 SwiftData CRUD 구현 |
| 📌 **Issue Number** | #86  |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/a42c6a40-0f1d-4372-9c9c-967d44803665" width='20'> **Figma** | [Link](<!-- URL -->) |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/c7f9920d-e975-4ed7-ad83-7e6e08611463" width='20'> **Notion** | [Link](<!-- URL -->) |

---

## 작업 사항
1. HIistoryListView에서 쓰일 TKConversation SwiftData 모델과 관련된 CRUD 메서드를 구현하였습니다. 
- 레츠가 올려주신 Location CRUD와 거의 유사한 형태로, 원래는 HistoryViewStore를 만드려고 했으나 완성된 작업물이 TKConversation 타입의 모델을 관리하는 매니저 역할에 더 가까워서 우선은 이런 방향으로 작업되었습니다. 오늘 안으로 빠르게 머지한 후에 84번 브랜치에서 Location과 Conversation을 통합하는 리팩토링이 진행될 예정입니다. 

---
