### PR TITLE
[Hotfix] `TKReducer` 의 기본 구현이었던 `callAsFunction` 을 제거(EXC_BAD_ACCESS)

### DIFF
--- a/talklat/talklat/Sources/Protocols/TKReducer.swift
+++ b/talklat/talklat/Sources/Protocols/TKReducer.swift
@@ -22,13 +22,6 @@ protocol TKReducer: ObservableObject, AnyObject {
      into newValue: Value)
 }
 
-extension TKReducer {
-    func callAsFunction<Value: Equatable>
-    (_ path: KeyPath<ViewState, Value>) -> Value {
-        self.callAsFunction(path)
-    }
-}
-
 // MARK: - USAGE EXAMPLE
 final class MyStore: TKReducer {
     struct ViewState {
@@ -46,6 +39,10 @@ final class MyStore: TKReducer {
         into newValue: Value)
     {
         self.viewState[keyPath: path] = newValue
+    }
+    
+    func callAsFunction<Value>(_ path: KeyPath<ViewState, Value>) -> Value where Value : Equatable {
+        self.viewState[keyPath: path]
     }
 }
 

--- a/talklat/talklat/Sources/Stores/ConversationViewStore.swift
+++ b/talklat/talklat/Sources/Stores/ConversationViewStore.swift
@@ -198,6 +198,10 @@ extension ConversationViewStore: TKReducer {
             self.viewState[keyPath: path] = newValue
         }
     }
+    
+    func callAsFunction<Value>(_ path: KeyPath<ConversationState, Value>) -> Value where Value : Equatable {
+        self.viewState[keyPath: path]
+    }
 }
 
 // MARK: Helper


### PR DESCRIPTION


## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->

<!-- Notion Card: Link (선택) -->

| ⚒️ Title | ``TKReducer` 버그 수정` | 
| :--- | :--- |
| 📜 **Description** | `TKReducer` 의 기본 구현이었던 `callAsFunction` 을 제거(EXC_BAD_ACCESS) |
| 📌 **Issue Number** | #90  |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/a42c6a40-0f1d-4372-9c9c-967d44803665" width='20'> **Figma** | _ |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/c7f9920d-e975-4ed7-ad83-7e6e08611463" width='20'> **Notion** | _ |

---

## 작업 사항
<!-- 1. MainIntroView의 ScrollView 구현 -->
1. `callAsFunction`이 현재 순환호출되는 문제가 있어서 기본 구현에서 제거합니다!

### `Logics`
```swift
protocol TKReducer: ObservableObject, AnyObject {
    associatedtype ViewState
    
    func callAsFunction<Value: Equatable>
    (_ path: KeyPath<ViewState, Value>) -> Value
    
    func reduce<Value: Equatable>
    (_ path: WritableKeyPath<ViewState, Value>,
     into newValue: Value)
}
```
- 기본 구현을 위한 확장 완전 제거

---

#### 기타 공유사항
<!-- 야기될 수 있는 사이드 이펙트, 조사가 필요한 내용 등을 작성합니다. --> 
1. TKReducer 관련 기본 구현 수정되었습니다!!! 꼭 확인하십시옹
@lianne-b  @MADElinessss  @alpaka99 