### PR TITLE
[Refactor/#107] HistoryListView, SearchView에 SwiftData 연결

### DIFF
--- a/talklat/talklat/Sources/Managers/DataTestingView.swift
+++ b/talklat/talklat/Sources/Managers/DataTestingView.swift
@@ -68,14 +68,13 @@ struct CreateConversationView: View {
             // 임시 자동생성
             let location = TKLocation(
                 latitude: 0.2,
-                longitude: 3.0,
-                blockName: "00동"
+                longitude: 3.1,
+                blockName: "상도동"
             )
             
             let conversation = TKConversation(
                 title: title,
                 createdAt: Date(),
-                updatedAt: Date(),
                 content: content,
                 location: location
             )

--- a/talklat/talklat/Sources/Managers/TKDataManager.swift
+++ b/talklat/talklat/Sources/Managers/TKDataManager.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftData
+import SwiftUI
 
 /*
  Context는 ModelContainer 안에 포함되어 있고, ModelContainer를 View 계층으로 흘려보내면 View 이외의 곳에서는 쓸 수가 없다.
@@ -66,3 +67,40 @@ extension TKDataManager {
         }
     }
 }
+
+extension TKDataManager {
+    // HistoryListView에서 쓰이는 specific fetch
+    internal func getLocationMatchingConversations(
+        location: TKLocation
+    ) -> [TKConversation] {
+        do {
+            let locationIndicator = location.blockName
+            let predicate = #Predicate<TKConversation> { conversation in
+                conversation.location?.blockName == locationIndicator
+            }
+            let descriptor = FetchDescriptor<TKConversation>(predicate: predicate)
+            
+            return try modelContext.fetch(descriptor)
+        } catch {
+            fatalError(error.localizedDescription)
+        }
+    }
+    
+    // HistoryListSearchView에서 쓰이는 specific fetch
+    internal func getContentMatchingLocations(
+        content: TKContent
+    ) -> [TKLocation] {
+        do {
+            let contentIndicator = content.conversation?.persistentModelID
+            let predicate = #Predicate<TKLocation> { location in
+                location.conversation?.persistentModelID == contentIndicator
+            }
+            let descriptor = FetchDescriptor<TKLocation>(predicate: predicate)
+            
+            return try modelContext.fetch(descriptor)
+        } catch {
+            fatalError(error.localizedDescription)
+        }
+    }
+}
+

--- a/talklat/talklat/Sources/Managers/TKSwiftDataStore.swift
+++ b/talklat/talklat/Sources/Managers/TKSwiftDataStore.swift
@@ -50,7 +50,28 @@ final class TKSwiftDataStore {
 
 // MARK: - Additional Methods
 extension TKSwiftDataStore {
-    // 
+    // HistoryListView에서 쓰이는 specific fetch
+    public func getLocationBasedConversations(location: TKLocation) -> [TKConversation] {
+        let conversations = dataManager.getLocationMatchingConversations(location: location)
+        return conversations
+    }
+    
+    // HistoryListSearchView에서 쓰이는 specific fetch
+    public func getContentBasedLocations(contents: [TKContent]) -> [TKLocation] {
+        contents.forEach { content in
+            var locations = dataManager.getContentMatchingLocations(content: content)
+        }
+        return filterDuplicatedBlockNames(locations: locations)
+    }
+    
+    // 중복되는 blockName을 제거한 [TKLocation]
+    public func filterDuplicatedBlockNames(locations: [TKLocation]) -> [TKLocation] {
+        let groupedLocations = Dictionary(grouping: locations, by: { $0.blockName })
+        let uniqueLocations = groupedLocations.compactMap { $0.value.first }
+        return uniqueLocations
+    }
 }
+
+
 
 

--- a/talklat/talklat/Sources/Models/TKContent.swift
+++ b/talklat/talklat/Sources/Models/TKContent.swift
@@ -25,3 +25,5 @@ final class TKContent {
         self.createdAt = createdAt
     }
 }
+
+

--- a/talklat/talklat/Sources/Models/TKConversation.swift
+++ b/talklat/talklat/Sources/Models/TKConversation.swift
@@ -8,7 +8,6 @@ import Foundation
 import SwiftData
 
 @Model
-
 final class TKConversation {
     var title: String
     var createdAt: Date
@@ -23,12 +22,12 @@ final class TKConversation {
     init(
         title: String,
         createdAt: Date,
-        updatedAt: Date,
-        content: [TKContent],
+        content: [TKContent]? = nil,
         location: TKLocation? = nil
     ) {
         self.title = title
         self.createdAt = createdAt
         self.content = content
+        self.location = location
     }
 }

--- a/talklat/talklat/Sources/Views/History/HistoryListSearchView.swift
+++ b/talklat/talklat/Sources/Views/History/HistoryListSearchView.swift
@@ -16,8 +16,6 @@ private enum searchStatus {
 struct HistoryListSearchView: View {
     var dataStore: TKSwiftDataStore
     
-    var sampleConversations: [TKConversationSample]
-    
     @State var matchingContents: [TKContent] = [TKContent(
         text: "",
         status: "answer",

--- a/talklat/talklat/Sources/Views/History/HistoryListSearchView.swift
+++ b/talklat/talklat/Sources/Views/History/HistoryListSearchView.swift
@@ -14,9 +14,15 @@ private enum searchStatus {
 }
 
 struct HistoryListSearchView: View {
+    var dataStore: TKSwiftDataStore
+    
     var sampleConversations: [TKConversationSample]
     
-    @State var matchingContents: [TKConversationSample.TKContent] = []
+    @State var matchingContents: [TKContent] = [TKContent(
+        text: "",
+        status: "answer",
+        createdAt: Date.now
+    )]
     @State private var searchStatus: searchStatus = .inactive
     @Binding internal var isSearching: Bool
     @Binding internal var searchText: String
@@ -30,8 +36,11 @@ struct HistoryListSearchView: View {
             case .resultFound:
                 ScrollView {
                     // TODO: matching [TKContent]의 matching [TKConversation.location]
-                    ForEach(0 ..< 1) { _ in
+                    ForEach(
+                        dataStore.getContentBasedLocations(contents: matchingContents)
+                    ) { location in
                         SearchResultSection(
+                            location: location,
                             matchingContents: $matchingContents,
                             searchText: $searchText
                         )
@@ -64,13 +73,13 @@ struct HistoryListSearchView: View {
             
             // Search Filter
             matchingContents = []
-            sampleConversations.forEach { conversation in
-                let matchingContent = conversation.content.filter({ content in
-                    content.text.contains(searchText)
-                })
-                
-                matchingContents.append(contentsOf: matchingContent)
-            }
+            
+            let matchingContent = dataStore.contents.filter({ content in
+                content.text.contains(searchText)
+            })
+            
+            matchingContents.append(contentsOf: matchingContent)
+            
         }
         .onChange(of: matchingContents) { _, _ in
             // TODO: if else matching TKContent 존재
@@ -89,7 +98,9 @@ struct HistoryListSearchView: View {
 
 // MARK: - (Matching) Location Unit
 struct SearchResultSection: View {
-    @Binding var matchingContents: [TKConversationSample.TKContent]
+    var location: TKLocation
+    
+    @Binding var matchingContents: [TKContent]
     @Binding var searchText: String
     
     var body: some View {
@@ -98,20 +109,20 @@ struct SearchResultSection: View {
             HStack {
                 Image(systemName: "location.fill")
                 
-                Text("서울특별시 송파동") // TODO: location.blockName
+                Text(location.blockName)
                     .foregroundColor(.gray800)
                     .font(.system(size: 20, weight: .bold))
                     .padding(.leading, -5)
                 
                 Spacer()
                 
-                Text("\(matchingContents.count)개 발견됨") // TODO: matching [TKContent].count
+                Text("\(matchingContents.count)개 발견됨")
                     .foregroundColor(.gray500)
                     .font(.system(size: 15, weight: .medium))
             }
             
             // Contents
-            ForEach(matchingContents, id: \.self) { content in // TODO: matching [TKContent]
+            ForEach(matchingContents, id: \.self) { content in
                 SearchResultItem(
                     matchingContent: content,
                     searchText: $searchText
@@ -124,7 +135,7 @@ struct SearchResultSection: View {
 
 // MARK: - (Matching) Conversation Item Unit
 struct SearchResultItem: View {
-    var matchingContent: TKConversationSample.TKContent
+    var matchingContent: TKContent
     
     @State var highlightIndex: String.Index = String.Index(utf16Offset: 0, in: "")
     @Binding var searchText: String
@@ -133,7 +144,7 @@ struct SearchResultItem: View {
         // Cell Contents
         HStack {
             VStack(alignment: .leading, spacing: 3) {
-                Text("Title") // TODO: title
+                Text(matchingContent.conversation?.title ?? "Talklat Title")
                     .font(.system(size: 17, weight: .medium))
                
                 // 검색 키워드와 일치하는 한 개의 TKContent.text
@@ -161,7 +172,7 @@ struct SearchResultItem: View {
                 }
                 
                 Text(
-                    matchingContent.createdAt.formatted( // TODO: createdAt
+                    matchingContent.createdAt.formatted( // TODO: format
                         date: .abbreviated,
                         time: .omitted
                    )

--- a/talklat/talklat/Sources/Views/History/HistoryListView.swift
+++ b/talklat/talklat/Sources/Views/History/HistoryListView.swift
@@ -25,88 +25,6 @@ struct HistoryListView: View {
     @State internal var isSearching: Bool = false
     @State internal var searchText: String = ""
     
-    private var sampleConversations: [TKConversationSample] {
-        [
-            // TKConversation 1
-            TKConversationSample(
-                id: UUID().uuidString,
-                content: [
-                    TKConversationSample.TKContent(
-                        id: UUID().uuidString,
-                        text: "안녕하세요 이거 혹시 새 제품 있나요?",
-                        status: "question",
-                        createdAt: Date.now
-                    ),
-                    TKConversationSample.TKContent(
-                        id: UUID().uuidString,
-                        text: "계속 찾고 있었는데 안보여요",
-                        status: "question",
-                        createdAt: Date.now
-                    )
-                ],
-                location: TKConversationSample.TKLocation(
-                    id: UUID().uuidString,
-                    latitude: 0.0,
-                    longitude: 0.0,
-                    blockName: "포항시 효자동"
-                ),
-                title: "메모 1",
-                createdAt: Date.now,
-                updatedAt: Date.now
-            ),
-            
-            // TKConversation 2
-            TKConversationSample(
-                id: UUID().uuidString,
-                content: [
-                    TKConversationSample.TKContent(
-                        id: UUID().uuidString,
-                        text: "안녕하세요 혹시 라네즈 쿠션 리필을 따로 판매하시나요?",
-                        status: "question",
-                        createdAt: Date.now
-                    ),
-                    TKConversationSample.TKContent(
-                        id: UUID().uuidString,
-                        text: "어 잠시만요",
-                        status: "answer",
-                        createdAt:  Date.now
-                    )
-                ],
-                location: TKConversationSample.TKLocation(
-                    id: UUID().uuidString,
-                    latitude: 3242.0,
-                    longitude: 34.0,
-                    blockName: "세종시 모모동"
-                ),
-                title: "대잠 올리브영",
-                createdAt: Date.now,
-                updatedAt: Date.now
-            ),
-            
-            // TKConversation 3
-            TKConversationSample(
-                id: UUID().uuidString,
-                content: [
-                    TKConversationSample.TKContent(
-                        id: UUID().uuidString,
-                        text: "안녕하세요 오늘 5시 예약한 00인데요, 제가 귀가 안좋아서, 말씀하실 때 핸드폰에 대고 말씀해주시면 텍스트로 읽어보겠습니다.",
-                        status: "question",
-                        createdAt:  Date.now
-                    )
-                ],
-                location: TKConversationSample.TKLocation(
-                    id: UUID().uuidString,
-                    latitude: 3242.0,
-                    longitude: 34.0,
-                    blockName: "세종시 모모동"
-                ),
-                title: "세종 철학관",
-                createdAt:  Date.now,
-                updatedAt:  Date.now
-            )
-        ]
-    }
-    
     // not in store
     @FocusState internal var isSearchFocused: Bool
    
@@ -178,7 +96,6 @@ struct HistoryListView: View {
                 // MARK: - History Search
                 HistoryListSearchView(
                     dataStore: dataStore,
-                    sampleConversations: sampleConversations,
                     isSearching: $isSearching,
                     searchText: $searchText
                 )

--- a/talklat/talklat/talklatApp.swift
+++ b/talklat/talklat/talklatApp.swift
@@ -16,6 +16,10 @@ struct talklatApp: App {
     
     private let appRootManager = AppRootManager()
     
+    init() {
+        print(URL.applicationSupportDirectory.path(percentEncoded: false))
+    }
+    
     var body: some Scene {
         WindowGroup {
             Group {
@@ -30,7 +34,8 @@ struct talklatApp: App {
                     
                 case .authCompleted:
                     NavigationStack {
-                        TKMainView()
+                        // TKMainView()
+                        HistoryListView()
                     }
                     
                 case .speechRecognitionAuthIncompleted
@@ -46,7 +51,6 @@ struct talklatApp: App {
                 Color.colorScheme = UITraitCollection.current.userInterfaceStyle
             }
         }
-//        .modelContainer(for: [TKConversation.self, TKContent.self])
     }
 }
 


### PR DESCRIPTION
## 개요 및 관련 이슈

| ⚒️ Title | `HistoryListView, SearchView에 SwiftData 연결` | 
| :--- | :--- |
| 📜 **Description** | description |
| 📌 **Issue Number** | #107  |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/a42c6a40-0f1d-4372-9c9c-967d44803665" width='20'> **Figma** | [Link](<!-- URL -->) |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/c7f9920d-e975-4ed7-ad83-7e6e08611463" width='20'> **Notion** | [Link](<!-- URL -->) |

---

## 작업 사항
1. HistoryListView, HistoryListSearchView의 TKSwiftDataStore를 통한 데이터 연결
2. History List 데이터 필터링을 위한 추가적인 메서드 구현 (TKSwiftDataStore에 위치) 
    - `getLocationBasedConversations`, `getContentBasedLocations`, `filterDuplicatedBlockNames`
    - 리팩토링시 제너릭으로 변경될 예정

### `Logics`
- 기능을 위해 일시적으로 만들어둔 메서드인데, 코드 정리는 모든 뷰의 브랜치를 병합하고나서 진행하겠습니다.
```swift
// HistoryListSearchView에서 쓰이는 specific fetch
public func getContentBasedLocations(contents: [TKContent]) -> [TKLocation] {
  contents.forEach { content in
    var locations = dataManager.getContentMatchingLocations(content: content)
  }
  return filterDuplicatedBlockNames(locations: locations)
}

// 중복되는 blockName을 제거한 [TKLocation]
public func filterDuplicatedBlockNames(locations: [TKLocation]) -> [TKLocation] {
  let groupedLocations = Dictionary(grouping: locations, by: { $0.blockName })
  let uniqueLocations = groupedLocations.compactMap { $0.value.first }
  return uniqueLocations
}
```

---

#### 기타 공유사항
- TKConversation에서 location init이 추가됐습니다.
- SwiftDataStore <- TKLocation, TKTextReplacement CRUD 관련 로직을 다 이 곳에 모으고, 합칠 수 있는 부분들은 나중에 합쳐져야 할 것 같습니다. 
