### PR TITLE
[Feat/#152] Text Design System 구현

### DIFF
--- a/talklat/bisdam.xcodeproj/project.pbxproj
+++ b/talklat/bisdam.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5713DC4C2B0B3BC600ECF34B /* BDText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5713DC4B2B0B3BC600ECF34B /* BDText.swift */; };
 		7E8D17D62ACE8AED00E904E5 /* talklatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17D52ACE8AED00E904E5 /* talklatTests.swift */; };
 		7E8D17E02ACE8AED00E904E5 /* talklatUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17DF2ACE8AED00E904E5 /* talklatUITests.swift */; };
 		7E8D17E22ACE8AED00E904E5 /* talklatUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8D17E12ACE8AED00E904E5 /* talklatUITestsLaunchTests.swift */; };
@@ -131,6 +132,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5713DC4B2B0B3BC600ECF34B /* BDText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BDText.swift; sourceTree = "<group>"; };
 		572304FE2B00AF350098FFF5 /* TextReplacementViewStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextReplacementViewStore.swift; sourceTree = "<group>"; };
 		572A82032B03300B00753516 /* Character+Consonant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Character+Consonant.swift"; sourceTree = "<group>"; };
 		574D418B2B05E662007EFE90 /* SettingsTeamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTeamView.swift; sourceTree = "<group>"; };
@@ -267,6 +269,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5713DC4A2B0B3B9100ECF34B /* DesignSystem */ = {
+			isa = PBXGroup;
+			children = (
+				5713DC4B2B0B3BC600ECF34B /* BDText.swift */,
+			);
+			path = DesignSystem;
+			sourceTree = "<group>";
+		};
 		57806D7E2AE28E85003A7B19 /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -476,6 +486,7 @@
 		7EF737952AD43E8300FCBA21 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				5713DC4A2B0B3B9100ECF34B /* DesignSystem */,
 				7E8445DD2ADFBBD900CFB8BC /* TKColor.swift */,
 				575677E02ADA6F13002E01BE /* TLTextField.swift */,
 				7E4A6CDC2AFB7F7C0014DDB8 /* TKOrbitCircles.swift */,
@@ -747,6 +758,7 @@
 				7EBD31342B0B2B1300D5514D /* TKHistoryInfoStore.swift in Sources */,
 				7EBD31352B0B2B1300D5514D /* TKDataManager.swift in Sources */,
 				7EBD31362B0B2B1300D5514D /* SpeechAuthManager.swift in Sources */,
+				5713DC4C2B0B3BC600ECF34B /* BDText.swift in Sources */,
 				7EBD31372B0B2B1300D5514D /* SignalExtractor.swift in Sources */,
 				7EBD31382B0B2B1300D5514D /* SpeechRecognizer.swift in Sources */,
 				7EBD31392B0B2B1300D5514D /* HapticManager.swift in Sources */,
@@ -957,7 +969,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 231117;
 				DEVELOPMENT_ASSET_PATHS = "\"talklat/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = 67M6ZS7KS6;
+				DEVELOPMENT_TEAM = MTUYFM4K8P;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = BISDAM;
@@ -996,7 +1008,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 231117;
 				DEVELOPMENT_ASSET_PATHS = "\"talklat/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = 67M6ZS7KS6;
+				DEVELOPMENT_TEAM = MTUYFM4K8P;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = BISDAM;

--- a/talklat/talklat/Sources/Views/Components/DesignSystem/BDText.swift
+++ b/talklat/talklat/Sources/Views/Components/DesignSystem/BDText.swift
@@ -1,0 +1,205 @@
+//
+//  BDText.swift
+//  bisdam
+//
+//  Created by 신정연 on 11/20/23.
+//
+
+import SwiftUI
+
+enum BDTextStyle {
+    // MARK: General Type
+    // Large Title Styles
+    case LT_B_120, LT_SB_120, LT_M_120
+    // Title Styles
+    case T1_B_120, T1_SB_120, T1_M_120
+    case T2_B_125, T2_SB_125, T2_M_125
+    case T3_B_125, T3_SB_125, T3_M_125
+    // Headline Styles
+    case H1_B_130, H1_SB_130, H1_M_130
+    case H2_SB_135, H2_M_135
+    // Footnote Styles
+    case FN_SB_135, FN_M_135
+    // Caption Styles
+    case C1_SB_130, C1_M_130
+    case C2_SB_120
+    // MARK: for Conversation+HistoryBubble Type (for C)
+    // Large Title Styles
+    case LT_B_160, LT_M_160
+    // Title Styles
+    case T1_B_170, T1_M_170
+    case T2_B_160, T2_M_160
+    case T3_B_160, T3_M_160
+    // Headline Styles
+    case H1_B_160, H1_M_160
+    case H2_SB_160, H2_M_160
+}
+
+struct BDText: View {
+    let text: String
+    private var style: BDTextStyle
+
+    init(
+        text: String,
+        style: BDTextStyle
+    ){
+        self.text = text
+        self.style = style
+    }
+    
+    var body: some View {
+        let (font, weight, lineHeightMultiplier) = propertiesForStyle(style)
+        let lineSpacing = calculateLineSpacing(for: font, with: lineHeightMultiplier)
+        let verticalPadding = calculateVerticalPadding(for: font, with: lineHeightMultiplier)
+        
+        Text(text)
+            .font(font)
+            .fontWeight(weight)
+            .lineSpacing(lineSpacing)
+            .padding(.vertical, verticalPadding)
+    }
+    
+    private func propertiesForStyle(_ style: BDTextStyle) -> (Font, Font.Weight, CGFloat) {
+        switch style {
+        // Large Title Styles
+        case .LT_B_120:
+            return (.largeTitle, .bold, 1.2)
+        case .LT_SB_120:
+            return (.largeTitle, .semibold, 1.2)
+        case .LT_M_120:
+            return (.largeTitle, .medium, 1.2)
+
+        // Title Styles
+        case .T1_B_120:
+            return (.title, .bold, 1.2)
+        case .T1_SB_120:
+            return (.title, .semibold, 1.2)
+        case .T1_M_120:
+            return (.title, .medium, 1.2)
+        case .T2_B_125:
+            return (.title2, .bold, 1.25)
+        case .T2_SB_125:
+            return (.title2, .semibold, 1.25)
+        case .T2_M_125:
+            return (.title2, .medium, 1.25)
+        case .T3_B_125:
+            return (.title3, .bold, 1.25)
+        case .T3_SB_125:
+            return (.title3, .semibold, 1.25)
+        case .T3_M_125:
+            return (.title3, .medium, 1.25)
+
+        // Headline Styles
+        case .H1_B_130:
+            return (.headline, .bold, 1.3)
+        case .H1_SB_130:
+            return (.headline, .semibold, 1.3)
+        case .H1_M_130:
+            return (.headline, .medium, 1.3)
+        case .H2_SB_135:
+            return (.subheadline, .semibold, 1.35)
+        case .H2_M_135:
+            return (.subheadline, .medium, 1.35)
+
+        // Footnote Styles
+        case .FN_SB_135:
+            return (.footnote, .semibold, 1.35)
+        case .FN_M_135:
+            return (.footnote, .medium, 1.35)
+
+        // Caption Styles
+        case .C1_SB_130:
+            return (.caption, .semibold, 1.3)
+        case .C1_M_130:
+            return (.caption, .medium, 1.3)
+        case .C2_SB_120:
+            return (.caption2, .semibold, 1.2)
+
+        // Conversation+HistoryBubble Type (for C)
+        // Large Title Styles
+        case .LT_B_160:
+            return (.largeTitle, .bold, 1.6)
+        case .LT_M_160:
+            return (.largeTitle, .medium, 1.6)
+
+        // Title Styles
+        case .T1_B_170:
+            return (.title, .bold, 1.7)
+        case .T1_M_170:
+            return (.title, .medium, 1.7)
+        case .T2_B_160:
+            return (.title2, .bold, 1.6)
+        case .T2_M_160:
+            return (.title2, .medium, 1.6)
+        case .T3_B_160:
+            return (.title3, .bold, 1.6)
+        case .T3_M_160:
+            return (.title3, .medium, 1.6)
+
+        // Headline Styles
+        case .H1_B_160:
+            return (.headline, .bold, 1.6)
+        case .H1_M_160:
+            return (.headline, .medium, 1.6)
+        case .H2_SB_160:
+            return (.subheadline, .semibold, 1.6)
+        case .H2_M_160:
+            return (.subheadline, .medium, 1.6)
+        }
+    }
+
+
+    // 피그마 기준 LineHeight 계산
+    private func calculateLineSpacing(for font: Font, with lineHeightMultiplier: CGFloat) -> CGFloat {
+        let fontHeight = fontHeight(for: font)
+        return fontHeight * lineHeightMultiplier - fontHeight
+    }
+
+    private func calculateVerticalPadding(for font: Font, with lineHeightMultiplier: CGFloat) -> CGFloat {
+        let fontHeight = fontHeight(for: font)
+        return (fontHeight * lineHeightMultiplier - fontHeight) / 2
+    }
+
+    private func fontHeight(for font: Font) -> CGFloat {
+        switch font {
+        case .largeTitle:
+            return 34
+        case .title:
+            return 28
+        case .title2:
+            return 22
+        case .title3:
+            return 20
+        case .headline:
+            return 17
+        case .subheadline:
+            return 15
+        case .footnote:
+            return 13
+        case .caption:
+            return 12
+        case .caption2:
+            return 11
+        default:
+            return 17
+        }
+    }
+
+}
+
+// Test View
+struct BDTextTestView: View {
+    var body: some View {
+        VStack {
+            BDText(text: "H1_B_130", style: .H1_B_130)
+            BDText(text: "FN_SB_135", style: .FN_SB_135)
+            BDText(text: "C1_M_130", style: .C1_M_130)
+        }
+    }
+}
+
+struct BDText_Previews: PreviewProvider {
+    static var previews: some View {
+        BDTextTestView()
+    }
+}


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->

<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `Text Design System 구현` | 
| :--- | :--- |
| 📜 **Description** | Text Design System 구현 |
| 📌 **Issue Number** | #152  |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/a42c6a40-0f1d-4372-9c9c-967d44803665" width='20'> **Figma** | [Link](<!-- URL -->) |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/c7f9920d-e975-4ed7-ad83-7e6e08611463" width='20'> **Notion** | [Link](<!-- URL -->) |

---

## 작업 사항
- 텍스트 관련 디자인 시스템을 구현해놨읍니다. 
(이제는 작업 단위 작게 해서 올리겠읍니다,,)

### `BDText`디자인 시스템
- BD: 비스담이라는 뜻

- propertiesForStyle: 
Font, FontWeight, 비율

- calculateLineSpacing, calculateVerticalPadding: 
비율과 각 폰트의 size 기준으로 linespacing과 padding값을 계산합니다. 모카가 피그마에 공식을 써주셔서 함수로 만들었어요!

사용법:
style에 피그마에 있는 폰트 스타일을 넣으면 됩니다.
```swift
BDText(text: "텍스트 내용", style: .H1_B_130)
```

<img width="1103" alt="스크린샷 2023-11-20 오후 5 35 37" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/88757043/9f659a93-5b20-4314-a93f-fe49d3e99c89">


## 기타 공유사항
- 만든 텍스트 디자인시스템 적용,,은 다른 디자인시스템들 만든 후에 적용하겠습니다. 혹시 지금해라! 싶으면 말씀해주십셔
- 매 다음으로는 텍스트필드 디자인시스템(기존에 3개 - SettingTRTextField, AWTextField, TLTextField) 하나로 통합..해서 만들겠습니다