### PR TITLE
Fix/#169 Settings 접근성 (화면 모드) 수정 작업

### DIFF
--- a/talklat/bisdam.xcodeproj/project.pbxproj
+++ b/talklat/bisdam.xcodeproj/project.pbxproj
@@ -111,6 +111,8 @@
 		7EBD31782B0B2B1300D5514D /* CustomHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0CBF222B0119030048C784 /* CustomHistoryView.swift */; };
 		7ED9AA082ACE8E4300B1EA4E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E8D17CB2ACE8AED00E904E5 /* Preview Assets.xcassets */; };
 		7ED9AA092ACE8E4300B1EA4E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E8D17C82ACE8AED00E904E5 /* Assets.xcassets */; };
+		EF41DD2B2B0CC26F009857E3 /* ColorSchemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF41DD2A2B0CC26F009857E3 /* ColorSchemeManager.swift */; };
+		EF41DD2D2B0CC29C009857E3 /* SettingsDisplayTestingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF41DD2C2B0CC29C009857E3 /* SettingsDisplayTestingView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -214,6 +216,8 @@
 		EF3B16C82B00C5FC00CDB484 /* TKSwiftDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKSwiftDataStore.swift; sourceTree = "<group>"; };
 		EF3B16CA2B00C61E00CDB484 /* DataTestingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataTestingView.swift; sourceTree = "<group>"; };
 		EF3F439D2AF7FF4700DFC98B /* TKConversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKConversation.swift; sourceTree = "<group>"; };
+		EF41DD2A2B0CC26F009857E3 /* ColorSchemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSchemeManager.swift; sourceTree = "<group>"; };
+		EF41DD2C2B0CC29C009857E3 /* SettingsDisplayTestingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDisplayTestingView.swift; sourceTree = "<group>"; };
 		EF67C64A2ACEB67000C1074E /* SpeechRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognizer.swift; sourceTree = "<group>"; };
 		EF67C6522AD13BF700C1074E /* SpeechAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechAuthManager.swift; sourceTree = "<group>"; };
 		EF67C6562AD1414300C1074E /* AuthorizationRequestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationRequestView.swift; sourceTree = "<group>"; };
@@ -528,6 +532,7 @@
 				CEF43C472ADA97FF00DE02A9 /* HapticManager.swift */,
 				5769BF9C2AFB5B900036CF3D /* TKTextReplacementManager.swift */,
 				EFFE7A6C2B05BC7000E17AA1 /* TKAuthManager.swift */,
+				EF41DD2A2B0CC26F009857E3 /* ColorSchemeManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -562,6 +567,7 @@
 				EF7BB33F2B05A13000F8FEC9 /* SettingTextField.swift */,
 				EF75C6112B06184C00F83FFE /* LoadingWebView.swift */,
 				EF75C6132B06191000F83FFE /* WebView.swift */,
+				EF41DD2C2B0CC29C009857E3 /* SettingsDisplayTestingView.swift */,
 			);
 			path = Settings_;
 			sourceTree = "<group>";
@@ -737,6 +743,7 @@
 				7EBD31292B0B2B1300D5514D /* Character+Consonant.swift in Sources */,
 				7EBD312A2B0B2B1300D5514D /* Date+Formatter.swift in Sources */,
 				7EBD312B2B0B2B1300D5514D /* EnvironmentValues+Namespace.swift in Sources */,
+				EF41DD2D2B0CC29C009857E3 /* SettingsDisplayTestingView.swift in Sources */,
 				7EBD312C2B0B2B1300D5514D /* Constants.swift in Sources */,
 				7EBD312D2B0B2B1300D5514D /* TKMainViewStore.swift in Sources */,
 				7EBD312E2B0B2B1300D5514D /* TKConversationViewStore.swift in Sources */,
@@ -775,6 +782,7 @@
 				7EBD31512B0B2B1300D5514D /* EmailView.swift in Sources */,
 				7EBD31522B0B2B1300D5514D /* SettingTextField.swift in Sources */,
 				7EBD31532B0B2B1300D5514D /* LoadingWebView.swift in Sources */,
+				EF41DD2B2B0CC26F009857E3 /* ColorSchemeManager.swift in Sources */,
 				7EBD31542B0B2B1300D5514D /* WebView.swift in Sources */,
 				7EBD31552B0B2B1300D5514D /* TKMainView.swift in Sources */,
 				7EBD31562B0B2B1300D5514D /* TKDraggableList.swift in Sources */,
@@ -957,7 +965,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 231117;
 				DEVELOPMENT_ASSET_PATHS = "\"talklat/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = 67M6ZS7KS6;
+				DEVELOPMENT_TEAM = 34U36L8239;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = BISDAM;
@@ -996,7 +1004,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 231117;
 				DEVELOPMENT_ASSET_PATHS = "\"talklat/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = 67M6ZS7KS6;
+				DEVELOPMENT_TEAM = 34U36L8239;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = BISDAM;

--- a/talklat/bisdam.xcodeproj/project.pbxproj
+++ b/talklat/bisdam.xcodeproj/project.pbxproj
@@ -101,7 +101,7 @@
 		7EBD316E2B0B2B1300D5514D /* CustomAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0CBF292B0287E50048C784 /* CustomAlertView.swift */; };
 		7EBD316F2B0B2B1300D5514D /* TKAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E892E402B0350CF00788DCF /* TKAlert.swift */; };
 		7EBD31702B0B2B1300D5514D /* TKToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E892E422B036A5900788DCF /* TKToast.swift */; };
-		7EBD31712B0B2B1300D5514D /* TKListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF7BB3242B03A38000F8FEC9 /* TKListCell.swift */; };
+		7EBD31712B0B2B1300D5514D /* BDListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF7BB3242B03A38000F8FEC9 /* BDListCell.swift */; };
 		7EBD31722B0B2B1300D5514D /* TKSplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E0313802B04F8BB0090A704 /* TKSplashView.swift */; };
 		7EBD31732B0B2B1300D5514D /* ScrollContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF90C51E2AE0B39B00A95BD7 /* ScrollContainer.swift */; };
 		7EBD31742B0B2B1300D5514D /* SwipeGuideMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF90C5202AE0FE9E00A95BD7 /* SwipeGuideMessage.swift */; };
@@ -226,7 +226,7 @@
 		EF7938962AFB748100402A4E /* HistoryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryListView.swift; sourceTree = "<group>"; };
 		EF79389A2AFB754100402A4E /* SampleTKConversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleTKConversation.swift; sourceTree = "<group>"; };
 		EF7BB3222B03970300F8FEC9 /* SettingsDisplayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDisplayView.swift; sourceTree = "<group>"; };
-		EF7BB3242B03A38000F8FEC9 /* TKListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKListCell.swift; sourceTree = "<group>"; };
+		EF7BB3242B03A38000F8FEC9 /* BDListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BDListCell.swift; sourceTree = "<group>"; };
 		EF7BB3282B03B78300F8FEC9 /* SettingsHapticView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHapticView.swift; sourceTree = "<group>"; };
 		EF7BB32A2B03BB4100F8FEC9 /* SettingsGestureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGestureView.swift; sourceTree = "<group>"; };
 		EF7BB32C2B03BCC200F8FEC9 /* SettingsAppInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAppInfoView.swift; sourceTree = "<group>"; };
@@ -489,7 +489,7 @@
 				CE0CBF292B0287E50048C784 /* CustomAlertView.swift */,
 				7E892E402B0350CF00788DCF /* TKAlert.swift */,
 				7E892E422B036A5900788DCF /* TKToast.swift */,
-				EF7BB3242B03A38000F8FEC9 /* TKListCell.swift */,
+				EF7BB3242B03A38000F8FEC9 /* BDListCell.swift */,
 				7E0313802B04F8BB0090A704 /* TKSplashView.swift */,
 			);
 			path = Components;
@@ -812,7 +812,7 @@
 				7EBD316E2B0B2B1300D5514D /* CustomAlertView.swift in Sources */,
 				7EBD316F2B0B2B1300D5514D /* TKAlert.swift in Sources */,
 				7EBD31702B0B2B1300D5514D /* TKToast.swift in Sources */,
-				7EBD31712B0B2B1300D5514D /* TKListCell.swift in Sources */,
+				7EBD31712B0B2B1300D5514D /* BDListCell.swift in Sources */,
 				7EBD31722B0B2B1300D5514D /* TKSplashView.swift in Sources */,
 				7EBD31732B0B2B1300D5514D /* ScrollContainer.swift in Sources */,
 				7EBD31742B0B2B1300D5514D /* SwipeGuideMessage.swift in Sources */,

--- a/talklat/talklat/Resources/Assets.xcassets/Colors/AlertBGWhite.colorset/Contents.json
+++ b/talklat/talklat/Resources/Assets.xcassets/Colors/AlertBGWhite.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x49",
+          "green" : "0x3F",
+          "red" : "0x3F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklat/Resources/Assets.xcassets/Colors/BaseBGWhite.colorset/Contents.json
+++ b/talklat/talklat/Resources/Assets.xcassets/Colors/BaseBGWhite.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklat/Resources/Assets.xcassets/Colors/Contents.json
+++ b/talklat/talklat/Resources/Assets.xcassets/Colors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklat/Resources/Assets.xcassets/Colors/GR1.colorset/Contents.json
+++ b/talklat/talklat/Resources/Assets.xcassets/Colors/GR1.colorset/Contents.json
@@ -1,0 +1,51 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "platform" : "ios",
+        "reference" : "systemGrayColor"
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF7",
+          "green" : "0xF2",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x24",
+          "green" : "0x1A",
+          "red" : "0x1A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklat/Resources/Assets.xcassets/Colors/GR2.colorset/Contents.json
+++ b/talklat/talklat/Resources/Assets.xcassets/Colors/GR2.colorset/Contents.json
@@ -1,0 +1,51 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "platform" : "universal",
+        "reference" : "systemGrayColor"
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xE5",
+          "red" : "0xE5"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x32",
+          "green" : "0x27",
+          "red" : "0x27"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklat/Resources/Assets.xcassets/Colors/GR3.colorset/Contents.json
+++ b/talklat/talklat/Resources/Assets.xcassets/Colors/GR3.colorset/Contents.json
@@ -1,0 +1,51 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "platform" : "universal",
+        "reference" : "systemGrayColor"
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC8",
+          "green" : "0xC0",
+          "red" : "0xC0"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x49",
+          "green" : "0x3F",
+          "red" : "0x3F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklat/Resources/Assets.xcassets/Colors/GR4.colorset/Contents.json
+++ b/talklat/talklat/Resources/Assets.xcassets/Colors/GR4.colorset/Contents.json
@@ -1,0 +1,51 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "platform" : "universal",
+        "reference" : "systemGrayColor"
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA4",
+          "green" : "0x9A",
+          "red" : "0x9A"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x61",
+          "green" : "0x57",
+          "red" : "0x57"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklat/Resources/Assets.xcassets/Colors/GR5.colorset/Contents.json
+++ b/talklat/talklat/Resources/Assets.xcassets/Colors/GR5.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7F",
+          "green" : "0x75",
+          "red" : "0x75"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7F",
+          "green" : "0x75",
+          "red" : "0x75"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklat/Resources/Assets.xcassets/Colors/GR6.colorset/Contents.json
+++ b/talklat/talklat/Resources/Assets.xcassets/Colors/GR6.colorset/Contents.json
@@ -1,0 +1,51 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "platform" : "universal",
+        "reference" : "systemGrayColor"
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x61",
+          "green" : "0x57",
+          "red" : "0x57"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA4",
+          "green" : "0x9A",
+          "red" : "0x9A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklat/Resources/Assets.xcassets/Colors/GR7.colorset/Contents.json
+++ b/talklat/talklat/Resources/Assets.xcassets/Colors/GR7.colorset/Contents.json
@@ -1,0 +1,51 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "platform" : "universal",
+        "reference" : "systemGrayColor"
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x49",
+          "green" : "0x3F",
+          "red" : "0x3F"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC8",
+          "green" : "0xC0",
+          "red" : "0xC0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklat/Resources/Assets.xcassets/Colors/GR8.colorset/Contents.json
+++ b/talklat/talklat/Resources/Assets.xcassets/Colors/GR8.colorset/Contents.json
@@ -1,0 +1,51 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "platform" : "universal",
+        "reference" : "systemGrayColor"
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x32",
+          "green" : "0x27",
+          "red" : "0x27"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xE5",
+          "red" : "0xE5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklat/Resources/Assets.xcassets/Colors/GR9.colorset/Contents.json
+++ b/talklat/talklat/Resources/Assets.xcassets/Colors/GR9.colorset/Contents.json
@@ -1,0 +1,51 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "platform" : "universal",
+        "reference" : "systemGrayColor"
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x24",
+          "green" : "0x1A",
+          "red" : "0x1A"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF7",
+          "green" : "0xF2",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklat/Resources/Assets.xcassets/Colors/OR5.colorset/Contents.json
+++ b/talklat/talklat/Resources/Assets.xcassets/Colors/OR5.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x38",
+          "green" : "0x68",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x38",
+          "green" : "0x68",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklat/Resources/Assets.xcassets/Colors/OR6.colorset/Contents.json
+++ b/talklat/talklat/Resources/Assets.xcassets/Colors/OR6.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x27",
+          "green" : "0x59",
+          "red" : "0xF7"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x27",
+          "green" : "0x59",
+          "red" : "0xF7"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklat/Resources/Assets.xcassets/Colors/RED.colorset/Contents.json
+++ b/talklat/talklat/Resources/Assets.xcassets/Colors/RED.colorset/Contents.json
@@ -1,0 +1,51 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "platform" : "universal",
+        "reference" : "systemRedColor"
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x27",
+          "green" : "0x59",
+          "red" : "0xF7"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2A",
+          "green" : "0x0D",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklat/Resources/Assets.xcassets/Colors/SheetBGWhite.colorset/Contents.json
+++ b/talklat/talklat/Resources/Assets.xcassets/Colors/SheetBGWhite.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x32",
+          "green" : "0x27",
+          "red" : "0x27"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/talklat/talklat/Sources/Managers/ColorSchemeManager.swift
+++ b/talklat/talklat/Sources/Managers/ColorSchemeManager.swift
@@ -1,0 +1,36 @@
+//
+//  ColorSchemeManager.swift
+//  bisdam
+//
+//  Created by Ye Eun Choi on 11/21/23.
+//
+
+import SwiftUI
+
+enum ColorScheme: Int {
+    case unspecified, light, dark
+}
+
+class ColorSchemeManager: ObservableObject {
+    @AppStorage("BDColorScheme") var colorScheme: ColorScheme = .unspecified {
+        didSet {
+            applyColorScheme()
+        }
+    }
+    
+    func applyColorScheme() {
+        keyWindow?.overrideUserInterfaceStyle = UIUserInterfaceStyle(
+            rawValue: colorScheme.rawValue
+        )!
+    }
+    
+    var keyWindow: UIWindow? {
+        guard let scene = UIApplication.shared.connectedScenes.first,
+              let windowSceneDelegate = scene.delegate as? UIWindowSceneDelegate,
+              let window = windowSceneDelegate.window else {
+                  return nil
+              }
+        
+        return window
+    }
+}

--- a/talklat/talklat/Sources/Views/Components/BDListCell.swift
+++ b/talklat/talklat/Sources/Views/Components/BDListCell.swift
@@ -7,7 +7,8 @@
 
 import SwiftUI
 
-struct TKListCell<LabelIcon: View, TrailingUI: View>: View {
+// TODO: 구조 변경
+struct BDListCell<LabelIcon: View, TrailingUI: View>: View {
     private var label: String
     private var leadingIcon: LabelIcon
     private var trailingUI: TrailingUI
@@ -51,13 +52,13 @@ struct TKListCell<LabelIcon: View, TrailingUI: View>: View {
 
 #Preview {
     VStack {
-        TKListCell(label: "리스트 아이템 1") {
+        BDListCell(label: "리스트 아이템 1") {
             Image(systemName: "sun.max.fill")
         } trailingUI: {
             Image(systemName: "chevron.right")
         }
         
-        TKListCell(label: "리스트 아이템 2") {
+        BDListCell(label: "리스트 아이템 2") {
         } trailingUI: {
             Toggle("", isOn: .constant(true))
         }

--- a/talklat/talklat/Sources/Views/Components/TKColor.swift
+++ b/talklat/talklat/Sources/Views/Components/TKColor.swift
@@ -8,7 +8,26 @@
 import SwiftUI
 
 extension Color {
-    static var colorScheme = UITraitCollection.current.userInterfaceStyle
+    // BD app's custom colorScheme
+//    static var BDColorScheme: ColorScheme {
+//        get {
+//            return UserDefaults.standard.object(
+//                forKey: "BDColorScheme"
+//            ) as? ColorScheme ?? .unspecified
+//        }
+//        set {
+//            UserDefaults.standard.set(
+//                newValue.rawValue,
+//                forKey: "BDColorScheme"
+//            )
+//            UserDefaults.standard.synchronize()
+//        }
+//    }
+    
+    static var BDColorScheme: ColorScheme = .unspecified
+    
+    // system's colorScheme
+    static var systemColorScheme = UITraitCollection.current.userInterfaceStyle
     
     static var OR5: Color {
         get { Color(hex: "FF6838") }
@@ -20,120 +39,208 @@ extension Color {
     
     static var BaseBGWhite: Color {
         get {
-            switch colorScheme {
-            case .light:
-                return Color.white
-            case .dark:
-                return Color(hex: "#000000")
-            case .unspecified:
-                return .white
-            @unknown default:
-                return .white
+            if BDColorScheme != .unspecified {
+                switch BDColorScheme {
+                case .light:
+                    return Color.white
+                case .dark:
+                    return Color(hex: "#000000")
+                case .unspecified:
+                    return .white
+                }
+            } else {
+                switch systemColorScheme {
+                case .light:
+                    return Color.white
+                case .dark:
+                    return Color(hex: "#000000")
+                case .unspecified:
+                    return .white
+                @unknown default:
+                    return .white
+                }
             }
         }
     }
     
     static var SheetBGWhite: Color {
         get {
-            switch colorScheme {
-            case .light:
-                return Color.white
-            case .dark:
-                return Color(hex: "#272732")
-            case .unspecified:
-                return .white
-            @unknown default:
-                return .white
+            if BDColorScheme != .unspecified {
+                switch BDColorScheme {
+                case .light:
+                    return Color.white
+                case .dark:
+                    return Color(hex: "#272732")
+                case .unspecified:
+                    return .white
+                }
+            } else {
+                switch systemColorScheme {
+                case .light:
+                    return Color.white
+                case .dark:
+                    return Color(hex: "#272732")
+                case .unspecified:
+                    return .white
+                @unknown default:
+                    return .white
+                }
             }
         }
     }
     
     static var AlertBGWhite: Color {
         get {
-            switch colorScheme {
-            case .light:
-                return Color.white
-            case .dark:
-                return Color(hex: "#3F3F49")
-            case .unspecified:
-                return .white
-            @unknown default:
-                return .white
+            if BDColorScheme != .unspecified {
+                switch BDColorScheme {
+                case .light:
+                    return Color.white
+                case .dark:
+                    return Color(hex: "#3F3F49")
+                case .unspecified:
+                    return .white
+                }
+            } else {
+                switch systemColorScheme {
+                case .light:
+                    return Color.white
+                case .dark:
+                    return Color(hex: "#3F3F49")
+                case .unspecified:
+                    return .white
+                @unknown default:
+                    return .white
+                }
             }
         }
     }
     
     static var RED: Color {
         get {
-            switch colorScheme {
-            case .light:
-                return Color(hex: "#F75927")
-            case .dark:
-                return Color(hex: "#FF0D2A")
-            case .unspecified:
-                return .red
-            @unknown default:
-                return .red
+            if BDColorScheme != .unspecified {
+                switch BDColorScheme {
+                case .light:
+                    return Color(hex: "#F75927")
+                case .dark:
+                    return Color(hex: "#FF0D2A")
+                case .unspecified:
+                    return .red
+                }
+            } else {
+                switch systemColorScheme {
+                case .light:
+                    return Color(hex: "#F75927")
+                case .dark:
+                    return Color(hex: "#FF0D2A")
+                case .unspecified:
+                    return .red
+                @unknown default:
+                    return .red
+                }
             }
         }
     }
-
+    
     static var GR1: Color {
         get {
-            switch colorScheme {
-            case .light:
-                return Color(hex: "#F2F2F7")
-            case .dark:
-                return Color(hex: "#1A1A24")
-            case .unspecified:
-                return Color.gray
-            @unknown default:
-                return Color.gray
+            if BDColorScheme != .unspecified {
+                switch BDColorScheme {
+                case .light:
+                    return Color(hex: "#F2F2F7")
+                case .dark:
+                    return Color(hex: "#1A1A24")
+                case .unspecified:
+                    return Color.gray
+                }
+            } else {
+                switch systemColorScheme {
+                case .light:
+                    return Color(hex: "#F2F2F7")
+                case .dark:
+                    return Color(hex: "#1A1A24")
+                case .unspecified:
+                    return Color.gray
+                @unknown default:
+                    return Color.gray
+                }
             }
         }
     }
     
     static var GR2: Color {
         get {
-            switch colorScheme {
-            case .light:
-                return Color(hex: "#E5E5EB")
-            case .dark:
-                return Color(hex: "#272732")
-            case .unspecified:
-                return Color.gray
-            @unknown default:
-                return Color.gray
+            if BDColorScheme != .unspecified {
+                switch BDColorScheme {
+                case .light:
+                    return Color(hex: "#E5E5EB")
+                case .dark:
+                    return Color(hex: "#272732")
+                case .unspecified:
+                    return Color.gray
+                }
+            } else {
+                switch systemColorScheme {
+                case .light:
+                    return Color(hex: "#E5E5EB")
+                case .dark:
+                    return Color(hex: "#272732")
+                case .unspecified:
+                    return Color.gray
+                @unknown default:
+                    return Color.gray
+                }
             }
         }
     }
     
     static var GR3: Color {
         get {
-            switch colorScheme {
-            case .light:
-                return Color(hex: "#C0C0C8")
-            case .dark:
-                return Color(hex: "#3F3F49")
-            case .unspecified:
-                return Color.gray
-            @unknown default:
-                return Color.gray
+            if BDColorScheme != .unspecified {
+                switch BDColorScheme {
+                case .light:
+                    return Color(hex: "#C0C0C8")
+                case .dark:
+                    return Color(hex: "#3F3F49")
+                case .unspecified:
+                    return Color.gray
+                }
+            } else {
+                switch systemColorScheme {
+                case .light:
+                    return Color(hex: "#C0C0C8")
+                case .dark:
+                    return Color(hex: "#3F3F49")
+                case .unspecified:
+                    return Color.gray
+                @unknown default:
+                    return Color.gray
+                }
             }
         }
     }
     
     static var GR4: Color {
         get {
-            switch colorScheme {
-            case .light:
-                return Color(hex: "#9A9AA4")
-            case .dark:
-                return Color(hex: "#575761")
-            case .unspecified:
-                return Color.gray
-            @unknown default:
-                return Color.gray
+            if BDColorScheme != .unspecified {
+                switch BDColorScheme {
+                case .light:
+                    return Color(hex: "#9A9AA4")
+                case .dark:
+                    return Color(hex: "#575761")
+                case .unspecified:
+                    return Color.gray
+                }
+            } else {
+                switch systemColorScheme {
+                case .light:
+                    return Color(hex: "#9A9AA4")
+                case .dark:
+                    return Color(hex: "#575761")
+                case .unspecified:
+                    return Color.gray
+                @unknown default:
+                    return Color.gray
+                }
             }
         }
     }
@@ -144,60 +251,104 @@ extension Color {
     
     static var GR6: Color {
         get {
-            switch colorScheme {
-            case .light:
-                return Color(hex: "#575761")
-            case .dark:
-                return Color(hex: "#9A9AA4")
-            case .unspecified:
-                return Color.gray
-            @unknown default:
-                return Color.gray
+            if BDColorScheme != .unspecified {
+                switch BDColorScheme {
+                case .light:
+                    return Color(hex: "#575761")
+                case .dark:
+                    return Color(hex: "#9A9AA4")
+                case .unspecified:
+                    return Color.gray
+                }
+            } else {
+                switch systemColorScheme {
+                case .light:
+                    return Color(hex: "#575761")
+                case .dark:
+                    return Color(hex: "#9A9AA4")
+                case .unspecified:
+                    return Color.gray
+                @unknown default:
+                    return Color.gray
+                }
             }
         }
     }
     
     static var GR7: Color {
         get {
-            switch colorScheme {
-            case .light:
-                return Color(hex: "#3F3F49")
-            case .dark:
-                return Color(hex: "#C0C0C8")
-            case .unspecified:
-                return Color.gray
-            @unknown default:
-                return Color.gray
+            if BDColorScheme != .unspecified {
+                switch BDColorScheme {
+                case .light:
+                    return Color(hex: "#3F3F49")
+                case .dark:
+                    return Color(hex: "#C0C0C8")
+                case .unspecified:
+                    return Color.gray
+                }
+            } else {
+                switch systemColorScheme {
+                case .light:
+                    return Color(hex: "#3F3F49")
+                case .dark:
+                    return Color(hex: "#C0C0C8")
+                case .unspecified:
+                    return Color.gray
+                @unknown default:
+                    return Color.gray
+                }
             }
         }
     }
     
     static var GR8: Color {
         get {
-            switch colorScheme {
-            case .light:
-                return Color(hex: "#272732")
-            case .dark:
-                return Color(hex: "#E5E5EB")
-            case .unspecified:
-                return Color.gray
-            @unknown default:
-                return Color.gray
+            if BDColorScheme != .unspecified {
+                switch BDColorScheme {
+                case .light:
+                    return Color(hex: "#272732")
+                case .dark:
+                    return Color(hex: "#E5E5EB")
+                case .unspecified:
+                    return Color.gray
+                }
+            } else {
+                switch systemColorScheme {
+                case .light:
+                    return Color(hex: "#272732")
+                case .dark:
+                    return Color(hex: "#E5E5EB")
+                case .unspecified:
+                    return Color.gray
+                @unknown default:
+                    return Color.gray
+                }
             }
         }
     }
     
     static var GR9: Color {
         get {
-            switch colorScheme {
-            case .light:
-                return Color(hex: "#1A1A24")
-            case .dark:
-                return Color(hex: "#F2F2F7")
-            case .unspecified:
-                return Color.gray
-            @unknown default:
-                return Color.gray
+            if BDColorScheme != .unspecified {
+                switch BDColorScheme {
+                case .light:
+                    return Color(hex: "#1A1A24")
+                case .dark:
+                    return Color(hex: "#F2F2F7")
+                case .unspecified:
+                    return Color.gray
+                }
+            } else {
+                switch systemColorScheme {
+                case .light:
+                    return Color(hex: "#1A1A24")
+                case .dark:
+                    return Color(hex: "#F2F2F7")
+                case .unspecified:
+                    return Color.gray
+                @unknown default:
+                    return Color.gray
+                }
             }
         }
     }

--- a/talklat/talklat/Sources/Views/Components/TKColor.swift
+++ b/talklat/talklat/Sources/Views/Components/TKColor.swift
@@ -8,375 +8,381 @@
 import SwiftUI
 
 extension Color {
-    // BD app's custom colorScheme
-//    static var BDColorScheme: ColorScheme {
-//        get {
-//            return UserDefaults.standard.object(
-//                forKey: "BDColorScheme"
-//            ) as? ColorScheme ?? .unspecified
-//        }
-//        set {
-//            UserDefaults.standard.set(
-//                newValue.rawValue,
-//                forKey: "BDColorScheme"
-//            )
-//            UserDefaults.standard.synchronize()
-//        }
-//    }
+    static let OR5 = Color("OR5")
+    static let OR6 = Color("OR6")
+   
+    static let BaseBGWhite = Color("BaseBGWhite")
+    static let SheetBGWhite = Color("SheetBGWhite")
+    static let AlertBGWhite = Color("AlertBGWhite")
     
-    static var BDColorScheme: ColorScheme = .unspecified
+    static let RED = Color("RED")
     
-    // system's colorScheme
-    static var systemColorScheme = UITraitCollection.current.userInterfaceStyle
-    
-    static var OR5: Color {
-        get { Color(hex: "FF6838") }
-    }
-    
-    static var OR6: Color {
-        get { Color(hex: "#F75927") }
-    }
-    
-    static var BaseBGWhite: Color {
-        get {
-            if BDColorScheme != .unspecified {
-                switch BDColorScheme {
-                case .light:
-                    return Color.white
-                case .dark:
-                    return Color(hex: "#000000")
-                case .unspecified:
-                    return .white
-                }
-            } else {
-                switch systemColorScheme {
-                case .light:
-                    return Color.white
-                case .dark:
-                    return Color(hex: "#000000")
-                case .unspecified:
-                    return .white
-                @unknown default:
-                    return .white
-                }
-            }
-        }
-    }
-    
-    static var SheetBGWhite: Color {
-        get {
-            if BDColorScheme != .unspecified {
-                switch BDColorScheme {
-                case .light:
-                    return Color.white
-                case .dark:
-                    return Color(hex: "#272732")
-                case .unspecified:
-                    return .white
-                }
-            } else {
-                switch systemColorScheme {
-                case .light:
-                    return Color.white
-                case .dark:
-                    return Color(hex: "#272732")
-                case .unspecified:
-                    return .white
-                @unknown default:
-                    return .white
-                }
-            }
-        }
-    }
-    
-    static var AlertBGWhite: Color {
-        get {
-            if BDColorScheme != .unspecified {
-                switch BDColorScheme {
-                case .light:
-                    return Color.white
-                case .dark:
-                    return Color(hex: "#3F3F49")
-                case .unspecified:
-                    return .white
-                }
-            } else {
-                switch systemColorScheme {
-                case .light:
-                    return Color.white
-                case .dark:
-                    return Color(hex: "#3F3F49")
-                case .unspecified:
-                    return .white
-                @unknown default:
-                    return .white
-                }
-            }
-        }
-    }
-    
-    static var RED: Color {
-        get {
-            if BDColorScheme != .unspecified {
-                switch BDColorScheme {
-                case .light:
-                    return Color(hex: "#F75927")
-                case .dark:
-                    return Color(hex: "#FF0D2A")
-                case .unspecified:
-                    return .red
-                }
-            } else {
-                switch systemColorScheme {
-                case .light:
-                    return Color(hex: "#F75927")
-                case .dark:
-                    return Color(hex: "#FF0D2A")
-                case .unspecified:
-                    return .red
-                @unknown default:
-                    return .red
-                }
-            }
-        }
-    }
-    
-    static var GR1: Color {
-        get {
-            if BDColorScheme != .unspecified {
-                switch BDColorScheme {
-                case .light:
-                    return Color(hex: "#F2F2F7")
-                case .dark:
-                    return Color(hex: "#1A1A24")
-                case .unspecified:
-                    return Color.gray
-                }
-            } else {
-                switch systemColorScheme {
-                case .light:
-                    return Color(hex: "#F2F2F7")
-                case .dark:
-                    return Color(hex: "#1A1A24")
-                case .unspecified:
-                    return Color.gray
-                @unknown default:
-                    return Color.gray
-                }
-            }
-        }
-    }
-    
-    static var GR2: Color {
-        get {
-            if BDColorScheme != .unspecified {
-                switch BDColorScheme {
-                case .light:
-                    return Color(hex: "#E5E5EB")
-                case .dark:
-                    return Color(hex: "#272732")
-                case .unspecified:
-                    return Color.gray
-                }
-            } else {
-                switch systemColorScheme {
-                case .light:
-                    return Color(hex: "#E5E5EB")
-                case .dark:
-                    return Color(hex: "#272732")
-                case .unspecified:
-                    return Color.gray
-                @unknown default:
-                    return Color.gray
-                }
-            }
-        }
-    }
-    
-    static var GR3: Color {
-        get {
-            if BDColorScheme != .unspecified {
-                switch BDColorScheme {
-                case .light:
-                    return Color(hex: "#C0C0C8")
-                case .dark:
-                    return Color(hex: "#3F3F49")
-                case .unspecified:
-                    return Color.gray
-                }
-            } else {
-                switch systemColorScheme {
-                case .light:
-                    return Color(hex: "#C0C0C8")
-                case .dark:
-                    return Color(hex: "#3F3F49")
-                case .unspecified:
-                    return Color.gray
-                @unknown default:
-                    return Color.gray
-                }
-            }
-        }
-    }
-    
-    static var GR4: Color {
-        get {
-            if BDColorScheme != .unspecified {
-                switch BDColorScheme {
-                case .light:
-                    return Color(hex: "#9A9AA4")
-                case .dark:
-                    return Color(hex: "#575761")
-                case .unspecified:
-                    return Color.gray
-                }
-            } else {
-                switch systemColorScheme {
-                case .light:
-                    return Color(hex: "#9A9AA4")
-                case .dark:
-                    return Color(hex: "#575761")
-                case .unspecified:
-                    return Color.gray
-                @unknown default:
-                    return Color.gray
-                }
-            }
-        }
-    }
-    
-    static var GR5: Color {
-        get { Color(hex: "#75757F") }
-    }
-    
-    static var GR6: Color {
-        get {
-            if BDColorScheme != .unspecified {
-                switch BDColorScheme {
-                case .light:
-                    return Color(hex: "#575761")
-                case .dark:
-                    return Color(hex: "#9A9AA4")
-                case .unspecified:
-                    return Color.gray
-                }
-            } else {
-                switch systemColorScheme {
-                case .light:
-                    return Color(hex: "#575761")
-                case .dark:
-                    return Color(hex: "#9A9AA4")
-                case .unspecified:
-                    return Color.gray
-                @unknown default:
-                    return Color.gray
-                }
-            }
-        }
-    }
-    
-    static var GR7: Color {
-        get {
-            if BDColorScheme != .unspecified {
-                switch BDColorScheme {
-                case .light:
-                    return Color(hex: "#3F3F49")
-                case .dark:
-                    return Color(hex: "#C0C0C8")
-                case .unspecified:
-                    return Color.gray
-                }
-            } else {
-                switch systemColorScheme {
-                case .light:
-                    return Color(hex: "#3F3F49")
-                case .dark:
-                    return Color(hex: "#C0C0C8")
-                case .unspecified:
-                    return Color.gray
-                @unknown default:
-                    return Color.gray
-                }
-            }
-        }
-    }
-    
-    static var GR8: Color {
-        get {
-            if BDColorScheme != .unspecified {
-                switch BDColorScheme {
-                case .light:
-                    return Color(hex: "#272732")
-                case .dark:
-                    return Color(hex: "#E5E5EB")
-                case .unspecified:
-                    return Color.gray
-                }
-            } else {
-                switch systemColorScheme {
-                case .light:
-                    return Color(hex: "#272732")
-                case .dark:
-                    return Color(hex: "#E5E5EB")
-                case .unspecified:
-                    return Color.gray
-                @unknown default:
-                    return Color.gray
-                }
-            }
-        }
-    }
-    
-    static var GR9: Color {
-        get {
-            if BDColorScheme != .unspecified {
-                switch BDColorScheme {
-                case .light:
-                    return Color(hex: "#1A1A24")
-                case .dark:
-                    return Color(hex: "#F2F2F7")
-                case .unspecified:
-                    return Color.gray
-                }
-            } else {
-                switch systemColorScheme {
-                case .light:
-                    return Color(hex: "#1A1A24")
-                case .dark:
-                    return Color(hex: "#F2F2F7")
-                case .unspecified:
-                    return Color.gray
-                @unknown default:
-                    return Color.gray
-                }
-            }
-        }
-    }
+    static let GR1 = Color("GR1")
+    static let GR2 = Color("GR2")
+    static let GR3 = Color("GR3")
+    static let GR4 = Color("GR4")
+    static let GR5 = Color("GR5")
+    static let GR6 = Color("GR6")
+    static let GR7 = Color("GR7")
+    static let GR8 = Color("GR8")
+    static let GR9 = Color("GR9")
 }
 
-struct ColorTestView: PreviewProvider {
-    static var previews: some View {
-        VStack {
-            Color.GR1
-                .overlay { Text("Color Gray 100") }
-            Color.GR2
-                .overlay { Text("Color Gray 200") }
-            Color.GR3
-                .overlay { Text("Color Gray 300") }
-            Color.GR4
-                .overlay { Text("Color Gray 400") }
-            Color.GR5
-                .overlay { Text("Color Gray 500") }
-            Color.GR6
-                .overlay { Text("Color Gray 600") }
-            Color.GR7
-                .overlay { Text("Color Gray 700") }
-            Color.GR8
-                .overlay { Text("Color Gray 800") }
-            Color.GR9
-                .overlay { Text("Color Gray 900") }
-        }
-        .ignoresSafeArea(edges: .bottom)
-        .background { Color.red }
-    }
-}
+//extension Color {
+//    // BISDAM app's colorScheme
+//    static var BDColorScheme: ColorScheme = .unspecified
+//    
+//    // system's colorScheme
+//    static var systemColorScheme = UITraitCollection.current.userInterfaceStyle
+//    
+//    static var OR5: Color {
+//        get { Color(hex: "FF6838") }
+//    }
+//    
+//    static var OR6: Color {
+//        get { Color(hex: "#F75927") }
+//    }
+//    
+//    static var BaseBGWhite: Color {
+//        get {
+//            if BDColorScheme != .unspecified {
+//                switch BDColorScheme {
+//                case .light:
+//                    return Color.white
+//                case .dark:
+//                    return Color(hex: "#000000")
+//                case .unspecified:
+//                    return .white
+//                }
+//            } else {
+//                switch systemColorScheme {
+//                case .light:
+//                    return Color.white
+//                case .dark:
+//                    return Color(hex: "#000000")
+//                case .unspecified:
+//                    return .white
+//                @unknown default:
+//                    return .white
+//                }
+//            }
+//        }
+//    }
+//    
+//    static var SheetBGWhite: Color {
+//        get {
+//            if BDColorScheme != .unspecified {
+//                switch BDColorScheme {
+//                case .light:
+//                    return Color.white
+//                case .dark:
+//                    return Color(hex: "#272732")
+//                case .unspecified:
+//                    return .white
+//                }
+//            } else {
+//                switch systemColorScheme {
+//                case .light:
+//                    return Color.white
+//                case .dark:
+//                    return Color(hex: "#272732")
+//                case .unspecified:
+//                    return .white
+//                @unknown default:
+//                    return .white
+//                }
+//            }
+//        }
+//    }
+//    
+//    static var AlertBGWhite: Color {
+//        get {
+//            if BDColorScheme != .unspecified {
+//                switch BDColorScheme {
+//                case .light:
+//                    return Color.white
+//                case .dark:
+//                    return Color(hex: "#3F3F49")
+//                case .unspecified:
+//                    return .white
+//                }
+//            } else {
+//                switch systemColorScheme {
+//                case .light:
+//                    return Color.white
+//                case .dark:
+//                    return Color(hex: "#3F3F49")
+//                case .unspecified:
+//                    return .white
+//                @unknown default:
+//                    return .white
+//                }
+//            }
+//        }
+//    }
+//    
+//    static var RED: Color {
+//        get {
+//            if BDColorScheme != .unspecified {
+//                switch BDColorScheme {
+//                case .light:
+//                    return Color(hex: "#F75927")
+//                case .dark:
+//                    return Color(hex: "#FF0D2A")
+//                case .unspecified:
+//                    return .red
+//                }
+//            } else {
+//                switch systemColorScheme {
+//                case .light:
+//                    return Color(hex: "#F75927")
+//                case .dark:
+//                    return Color(hex: "#FF0D2A")
+//                case .unspecified:
+//                    return .red
+//                @unknown default:
+//                    return .red
+//                }
+//            }
+//        }
+//    }
+//    
+//    static var GR1: Color {
+//        get {
+//            if BDColorScheme != .unspecified {
+//                switch BDColorScheme {
+//                case .light:
+//                    return Color(hex: "#F2F2F7")
+//                case .dark:
+//                    return Color(hex: "#1A1A24")
+//                case .unspecified:
+//                    return Color.gray
+//                }
+//            } else {
+//                switch systemColorScheme {
+//                case .light:
+//                    return Color(hex: "#F2F2F7")
+//                case .dark:
+//                    return Color(hex: "#1A1A24")
+//                case .unspecified:
+//                    return Color.gray
+//                @unknown default:
+//                    return Color.gray
+//                }
+//            }
+//        }
+//    }
+//    
+//    static var GR2: Color {
+//        get {
+//            if BDColorScheme != .unspecified {
+//                switch BDColorScheme {
+//                case .light:
+//                    return Color(hex: "#E5E5EB")
+//                case .dark:
+//                    return Color(hex: "#272732")
+//                case .unspecified:
+//                    return Color.gray
+//                }
+//            } else {
+//                switch systemColorScheme {
+//                case .light:
+//                    return Color(hex: "#E5E5EB")
+//                case .dark:
+//                    return Color(hex: "#272732")
+//                case .unspecified:
+//                    return Color.gray
+//                @unknown default:
+//                    return Color.gray
+//                }
+//            }
+//        }
+//    }
+//    
+//    static var GR3: Color {
+//        get {
+//            if BDColorScheme != .unspecified {
+//                switch BDColorScheme {
+//                case .light:
+//                    return Color(hex: "#C0C0C8")
+//                case .dark:
+//                    return Color(hex: "#3F3F49")
+//                case .unspecified:
+//                    return Color.gray
+//                }
+//            } else {
+//                switch systemColorScheme {
+//                case .light:
+//                    return Color(hex: "#C0C0C8")
+//                case .dark:
+//                    return Color(hex: "#3F3F49")
+//                case .unspecified:
+//                    return Color.gray
+//                @unknown default:
+//                    return Color.gray
+//                }
+//            }
+//        }
+//    }
+//    
+//    static var GR4: Color {
+//        get {
+//            if BDColorScheme != .unspecified {
+//                switch BDColorScheme {
+//                case .light:
+//                    return Color(hex: "#9A9AA4")
+//                case .dark:
+//                    return Color(hex: "#575761")
+//                case .unspecified:
+//                    return Color.gray
+//                }
+//            } else {
+//                switch systemColorScheme {
+//                case .light:
+//                    return Color(hex: "#9A9AA4")
+//                case .dark:
+//                    return Color(hex: "#575761")
+//                case .unspecified:
+//                    return Color.gray
+//                @unknown default:
+//                    return Color.gray
+//                }
+//            }
+//        }
+//    }
+//    
+//    static var GR5: Color {
+//        get { Color(hex: "#75757F") }
+//    }
+//    
+//    static var GR6: Color {
+//        get {
+//            if BDColorScheme != .unspecified {
+//                switch BDColorScheme {
+//                case .light:
+//                    return Color(hex: "#575761")
+//                case .dark:
+//                    return Color(hex: "#9A9AA4")
+//                case .unspecified:
+//                    return Color.gray
+//                }
+//            } else {
+//                switch systemColorScheme {
+//                case .light:
+//                    return Color(hex: "#575761")
+//                case .dark:
+//                    return Color(hex: "#9A9AA4")
+//                case .unspecified:
+//                    return Color.gray
+//                @unknown default:
+//                    return Color.gray
+//                }
+//            }
+//        }
+//    }
+//    
+//    static var GR7: Color {
+//        get {
+//            if BDColorScheme != .unspecified {
+//                switch BDColorScheme {
+//                case .light:
+//                    return Color(hex: "#3F3F49")
+//                case .dark:
+//                    return Color(hex: "#C0C0C8")
+//                case .unspecified:
+//                    return Color.gray
+//                }
+//            } else {
+//                switch systemColorScheme {
+//                case .light:
+//                    return Color(hex: "#3F3F49")
+//                case .dark:
+//                    return Color(hex: "#C0C0C8")
+//                case .unspecified:
+//                    return Color.gray
+//                @unknown default:
+//                    return Color.gray
+//                }
+//            }
+//        }
+//    }
+//    
+//    static var GR8: Color {
+//        get {
+//            if BDColorScheme != .unspecified {
+//                switch BDColorScheme {
+//                case .light:
+//                    return Color(hex: "#272732")
+//                case .dark:
+//                    return Color(hex: "#E5E5EB")
+//                case .unspecified:
+//                    return Color.gray
+//                }
+//            } else {
+//                switch systemColorScheme {
+//                case .light:
+//                    return Color(hex: "#272732")
+//                case .dark:
+//                    return Color(hex: "#E5E5EB")
+//                case .unspecified:
+//                    return Color.gray
+//                @unknown default:
+//                    return Color.gray
+//                }
+//            }
+//        }
+//    }
+//    
+//    static var GR9: Color {
+//        get {
+//            if BDColorScheme != .unspecified {
+//                switch BDColorScheme {
+//                case .light:
+//                    return Color(hex: "#1A1A24")
+//                case .dark:
+//                    return Color(hex: "#F2F2F7")
+//                case .unspecified:
+//                    return Color.gray
+//                }
+//            } else {
+//                switch systemColorScheme {
+//                case .light:
+//                    return Color(hex: "#1A1A24")
+//                case .dark:
+//                    return Color(hex: "#F2F2F7")
+//                case .unspecified:
+//                    return Color.gray
+//                @unknown default:
+//                    return Color.gray
+//                }
+//            }
+//        }
+//    }
+//}
+//
+//struct ColorTestView: PreviewProvider {
+//    static var previews: some View {
+//        VStack {
+//            Color.GR1
+//                .overlay { Text("Color Gray 100") }
+//            Color.GR2
+//                .overlay { Text("Color Gray 200") }
+//            Color.GR3
+//                .overlay { Text("Color Gray 300") }
+//            Color.GR4
+//                .overlay { Text("Color Gray 400") }
+//            Color.GR5
+//                .overlay { Text("Color Gray 500") }
+//            Color.GR6
+//                .overlay { Text("Color Gray 600") }
+//            Color.GR7
+//                .overlay { Text("Color Gray 700") }
+//            Color.GR8
+//                .overlay { Text("Color Gray 800") }
+//            Color.GR9
+//                .overlay { Text("Color Gray 900") }
+//        }
+//        .ignoresSafeArea(edges: .bottom)
+//        .background { Color.red }
+//    }
+//}

--- a/talklat/talklat/Sources/Views/Main/TKMainView.swift
+++ b/talklat/talklat/Sources/Views/Main/TKMainView.swift
@@ -115,8 +115,7 @@ struct TKMainView: View {
             
             ToolbarItem(placement: .topBarTrailing) {
                 NavigationLink {
-//                    HistoryListView()
-                    SettingsTeamView()
+                    HistoryListView()
                 } label: {
                     Image(systemName: "list.bullet.rectangle.fill")
                         .foregroundStyle(Color.GR3)

--- a/talklat/talklat/Sources/Views/Settings_/SettingsAppInfoView.swift
+++ b/talklat/talklat/Sources/Views/Settings_/SettingsAppInfoView.swift
@@ -76,7 +76,7 @@ struct SettingsAppInfoView: View {
                             .ignoresSafeArea(edges: .bottom)
                     }
                 } label: {
-                    TKListCell(label: info.rawValue) {
+                    BDListCell(label: info.rawValue) {
                     } trailingUI: {
                         Image(systemName: "chevron.right")
                     }

--- a/talklat/talklat/Sources/Views/Settings_/SettingsDisplayTestingView.swift
+++ b/talklat/talklat/Sources/Views/Settings_/SettingsDisplayTestingView.swift
@@ -1,0 +1,41 @@
+//
+//  SettingsDisplayTestingView.swift
+//  bisdam
+//
+//  Created by Ye Eun Choi on 11/21/23.
+//
+
+import SwiftUI
+
+struct SettingsDisplayTestingView: View {
+    @Environment(\.colorScheme) var current
+    @EnvironmentObject var colorSchemeManager: ColorSchemeManager
+   
+    static var BDColorScheme: ColorScheme {
+        get {
+            return UserDefaults.standard.object(
+                forKey: "BDColorScheme"
+            ) as? ColorScheme ?? .unspecified
+        }
+        set {
+            UserDefaults.standard.set(
+                newValue.rawValue,
+                forKey: "BDColorScheme"
+            )
+            UserDefaults.standard.synchronize()
+        }
+    }
+    
+    var body: some View {
+        VStack {
+            Text("TestingView..")
+        }
+        .onAppear {
+            print("----> BDColorScheme: ", SettingsDisplayTestingView.BDColorScheme)
+        }
+    }
+}
+
+#Preview {
+    SettingsDisplayTestingView()
+}

--- a/talklat/talklat/Sources/Views/Settings_/SettingsDisplayView.swift
+++ b/talklat/talklat/Sources/Views/Settings_/SettingsDisplayView.swift
@@ -6,61 +6,45 @@
 //
 
 import SwiftUI
+
+private enum ColorSchemeType: String, CaseIterable {
+    case device = "시스템 설정과 동일"
+    case light = "밝은 모드"
+    case dark = "어두운 모드"
+    
+    var theme: ColorScheme {
+        switch self {
+        case .device: return ColorScheme.unspecified
+        case .light: return ColorScheme.light
+        case .dark: return ColorScheme.dark
+        }
+    }
+}
+
 struct SettingsDisplayView: View {
-    @Environment(\.colorScheme) var current
-    @EnvironmentObject var colorSchemeManager: ColorSchemeManager
-    
-    @State private var selectedTheme: ColorScheme = .dark
-    
     @AppStorage("BDColorScheme") var BDColorScheme = ColorScheme.unspecified
+    @EnvironmentObject var colorSchemeManager: ColorSchemeManager
+    @State private var selectedTheme: ColorScheme = .dark
     
     var body: some View {
         VStack {
-            TKListCell(label: "시스템과 동일") {
-            } trailingUI: {
-                if selectedTheme == ColorScheme.unspecified {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 21))
-                } else {
-                    Image(systemName: "circlebadge")
-                        .font(.system(size: 26.8))
+            ForEach(ColorSchemeType.allCases, id: \.self) { type in
+                BDListCell(label: type.rawValue) {
+                } trailingUI: {
+                    if selectedTheme == type.theme {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 21))
+                    } else {
+                        Image(systemName: "circlebadge")
+                            .font(.system(size: 26.8))
+                    }
+                }
+                .onTapGesture {
+                    selectedTheme = type.theme
+                    colorSchemeManager.colorScheme = selectedTheme
                 }
             }
-            .onTapGesture {
-                selectedTheme = ColorScheme.unspecified
-                colorSchemeManager.colorScheme = selectedTheme
-            }
-            
-            TKListCell(label: "밝은 모드") {
-            } trailingUI: {
-                if selectedTheme == ColorScheme.light {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 21))
-                } else {
-                    Image(systemName: "circlebadge")
-                        .font(.system(size: 26.8))
-                }
-            }
-            .onTapGesture {
-                selectedTheme = ColorScheme.light
-                colorSchemeManager.colorScheme = selectedTheme
-            }
-            
-            TKListCell(label:"어두운 모드") {
-            } trailingUI: {
-                if selectedTheme == ColorScheme.dark {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 21))
-                } else {
-                    Image(systemName: "circlebadge")
-                        .font(.system(size: 26.8))
-                }
-            }
-            .onTapGesture {
-                selectedTheme = ColorScheme.dark
-                colorSchemeManager.colorScheme = selectedTheme
-            }
-            
+
             Spacer()
         }
         .padding(.horizontal, 16)
@@ -69,8 +53,6 @@ struct SettingsDisplayView: View {
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             selectedTheme = colorSchemeManager.colorScheme
-            
-            print("---> BDColorScheme: ", BDColorScheme)
         }
     }
 }

--- a/talklat/talklat/Sources/Views/Settings_/SettingsDisplayView.swift
+++ b/talklat/talklat/Sources/Views/Settings_/SettingsDisplayView.swift
@@ -6,40 +6,59 @@
 //
 
 import SwiftUI
-
 struct SettingsDisplayView: View {
-    enum DisplayMode: String, CaseIterable {
-        case systemMode = "시스템 설정과 동일"
-        case lightMode = "밝은 모드"
-        case darkMode = "어두운 모드"
-    }
-
-    @Environment(\.colorScheme) var colorScheme
-   
-    @State private var selectedMode: DisplayMode = .systemMode
+    @Environment(\.colorScheme) var current
+    @EnvironmentObject var colorSchemeManager: ColorSchemeManager
+    
+    @State private var selectedTheme: ColorScheme = .dark
+    
+    @AppStorage("BDColorScheme") var BDColorScheme = ColorScheme.unspecified
     
     var body: some View {
         VStack {
-            ForEach(DisplayMode.allCases, id: \.self) { label in
-                TKListCell(label: label.rawValue) {
-                } trailingUI: {
-                    switch selectedMode {
-                    case .systemMode, .lightMode, .darkMode:
-                        if selectedMode == label {
-                            Image(systemName: "checkmark.circle.fill")
-                                .font(.system(size: 21))
-                                .onTapGesture {
-                                    selectedMode = label
-                                }
-                        } else {
-                            Image(systemName: "circlebadge")
-                                .font(.system(size: 26.8))
-                                .onTapGesture {
-                                    selectedMode = label
-                                }
-                        }
-                    }
+            TKListCell(label: "시스템과 동일") {
+            } trailingUI: {
+                if selectedTheme == ColorScheme.unspecified {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 21))
+                } else {
+                    Image(systemName: "circlebadge")
+                        .font(.system(size: 26.8))
                 }
+            }
+            .onTapGesture {
+                selectedTheme = ColorScheme.unspecified
+                colorSchemeManager.colorScheme = selectedTheme
+            }
+            
+            TKListCell(label: "밝은 모드") {
+            } trailingUI: {
+                if selectedTheme == ColorScheme.light {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 21))
+                } else {
+                    Image(systemName: "circlebadge")
+                        .font(.system(size: 26.8))
+                }
+            }
+            .onTapGesture {
+                selectedTheme = ColorScheme.light
+                colorSchemeManager.colorScheme = selectedTheme
+            }
+            
+            TKListCell(label:"어두운 모드") {
+            } trailingUI: {
+                if selectedTheme == ColorScheme.dark {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 21))
+                } else {
+                    Image(systemName: "circlebadge")
+                        .font(.system(size: 26.8))
+                }
+            }
+            .onTapGesture {
+                selectedTheme = ColorScheme.dark
+                colorSchemeManager.colorScheme = selectedTheme
             }
             
             Spacer()
@@ -48,17 +67,10 @@ struct SettingsDisplayView: View {
         .padding(.top, 24)
         .navigationTitle("화면 모드")
         .navigationBarTitleDisplayMode(.inline)
-    }
-    
-    // TODO: - 지금은 작동이 안됨. 나중에 작업.
-    private func switchDisplayMode() -> ColorScheme {
-        switch selectedMode {
-        case .lightMode:
-            return ColorScheme.light
-        case .darkMode:
-            return ColorScheme.dark
-        default:
-            return ColorScheme.light
+        .onAppear {
+            selectedTheme = colorSchemeManager.colorScheme
+            
+            print("---> BDColorScheme: ", BDColorScheme)
         }
     }
 }

--- a/talklat/talklat/Sources/Views/Settings_/SettingsGestureView.swift
+++ b/talklat/talklat/Sources/Views/Settings_/SettingsGestureView.swift
@@ -17,7 +17,7 @@ struct SettingsGestureView: View {
                 .font(.system(size: 15, weight: .semibold))
                 .padding(.leading, 16)
             
-            TKListCell(label: "플립 제스처") {
+            BDListCell(label: "플립 제스처") {
                 } trailingUI: {
                     Toggle("", isOn: $isGestureEnabled)
                 }

--- a/talklat/talklat/Sources/Views/Settings_/SettingsGuidingView.swift
+++ b/talklat/talklat/Sources/Views/Settings_/SettingsGuidingView.swift
@@ -12,7 +12,7 @@ struct SettingsGuidingView: View {
     
     var body: some View {
         VStack {
-            TKListCell(label: "대화 시작 시 안내 문구 사용") {
+            BDListCell(label: "대화 시작 시 안내 문구 사용") {
                 } trailingUI: {
                     Toggle(
                         "",
@@ -31,7 +31,7 @@ struct SettingsGuidingView: View {
                 SettingsGuidingEditView()
                 
             } label: {
-                TKListCell(label: "안내 문구 편집") {
+                BDListCell(label: "안내 문구 편집") {
                     } trailingUI: {
                         Image(systemName: "chevron.right")
                             .foregroundColor(

--- a/talklat/talklat/Sources/Views/Settings_/SettingsHapticView.swift
+++ b/talklat/talklat/Sources/Views/Settings_/SettingsHapticView.swift
@@ -17,7 +17,7 @@ struct SettingsHapticView: View {
                 .font(.system(size: 15, weight: .semibold))
                 .padding(.leading, 16)
             
-            TKListCell(label: "진동") {
+            BDListCell(label: "진동") {
                 } trailingUI: {
                     Toggle("", isOn: $isHapticEnabled)
                 }

--- a/talklat/talklat/Sources/Views/Settings_/SettingsHelpView.swift
+++ b/talklat/talklat/Sources/Views/Settings_/SettingsHelpView.swift
@@ -17,7 +17,7 @@ struct SettingsHelpView: View {
     
     var body: some View {
         VStack {
-            TKListCell(label: "문의 및 오류 신고하기") {
+            BDListCell(label: "문의 및 오류 신고하기") {
             } trailingUI: {
                 Image(systemName: "chevron.right")
             }

--- a/talklat/talklat/Sources/Views/Settings_/SettingsListView.swift
+++ b/talklat/talklat/Sources/Views/Settings_/SettingsListView.swift
@@ -122,7 +122,7 @@ struct SettingsListView: View {
                                     SettingsHelpView()
                                 }
                             } label: {
-                                TKListCell(label: item.rawValue) {
+                                BDListCell(label: item.rawValue) {
                                     Image(systemName: item.icon)
                                 } trailingUI: {
                                     Image(systemName: "chevron.right")

--- a/talklat/talklat/Sources/Views/Settings_/SettingsListView.swift
+++ b/talklat/talklat/Sources/Views/Settings_/SettingsListView.swift
@@ -9,23 +9,20 @@ import SwiftUI
 
 private enum SectionType: String, CaseIterable {
     case textReplacement = "텍스트 대치"
-//    case guidingMessage = "안내 문구"
-    // case displayMode = "화면 모드"
+    case guidingMessage = "안내 문구"
+    case displayMode = "화면 모드"
     // case haptics = "진동"
-    // case gesture = "제스처"
-    // case appServiceInfo = "앱 및 서비스 정보"
+    case gesture = "제스처"
     case dataPolicyInfo = "개인정보 처리방침"
     case creators = "만든 사람들"
     case needHelp = "도움이 필요하신가요?"
     
     var category: String {
         switch self {
-        case .textReplacement: return "대화"
-//        case .guidingMessage: return "대화"
-        // case .displayMode: return "접근성"
+        case .textReplacement, .guidingMessage: return "대화"
+        case .displayMode: return "접근성"
         // case .haptics: return "일반"
-        // case .gesture: return "실험실"
-        // .appServiceInfo -> .dataPolicyInfo
+        case .gesture: return "실험실"
         case .dataPolicyInfo, .creators: return "정보"
         case .needHelp: return "지원"
         }
@@ -34,11 +31,10 @@ private enum SectionType: String, CaseIterable {
     var icon: String {
         switch self {
         case .textReplacement: return "bubble.left.and.text.bubble.right.fill"
-//        case .guidingMessage: return "quote.opening"
-        // case .displayMode: return "sun.max.fill"
+        case .guidingMessage: return "quote.opening"
+        case .displayMode: return "sun.max.fill"
         // case .haptics: return "water.waves"
-        // case .gesture: return "hands.and.sparkles.fill"
-        // case .appServiceInfo: return "app.badge.fill"
+        case .gesture: return "hands.and.sparkles.fill"
         case .dataPolicyInfo: return "app.badge.fill"
         case .creators: return "person.2.fill"
         case .needHelp: return "person.crop.circle.fill.badge.questionmark"
@@ -48,69 +44,73 @@ private enum SectionType: String, CaseIterable {
 
 struct SettingsListView: View {
     @Environment(\.dismiss) var dismiss
-    
-    @State private var authStatus: AuthStatus = .authCompleted
+    @EnvironmentObject var authManager: TKAuthManager
+    // @State private var authStatus: AuthStatus = .authCompleted
     
     private let sectionCategories: [String] = [
-        "대화", "정보", "지원" // TODO: - "접근성", "일반", "실험실" 추가
+        "대화", "접근성", "실험실", "정보", "지원" // TODO: "일반" 추가
     ]
     
     var body: some View {
         ScrollView {
-            VStack {
-                // TODO: appRootManager.switchAuthStatus에서 분기처리 변경 (위치 권한 분기 추가)
-                switch authStatus {
-                case .microphoneAuthIncompleted, .speechRecognitionAuthIncompleted:
-                    authNoticeBuilder(noticeItem: "마이크와 음성인식")
-                
-                    // TODO: case .locationAuthIncompleted:
-                    // authNoticeBuilder(noticeItem: "위치")
-                    
-                case .authIncompleted:
-                    authNoticeBuilder(noticeItem: "마이크와 음성인식")
-                    authNoticeBuilder(noticeItem: "위치")
-                    
-                default:
-                    Color.clear
-                        .frame(height: 0)
-                }
-            }
-            .padding(.top, 10)
-            .padding(.bottom, authStatus == .authCompleted ? 0 : 24)
+//            VStack {
+//                switch authManager.authStatus {
+//                case .microphoneAuthIncompleted,
+//                        .speechRecognitionAuthIncompleted:
+//                    authNoticeBuilder(noticeItem: "마이크 및 음성인식")
+//                    
+//                case .locationAuthIncompleted:
+//                    authNoticeBuilder(noticeItem: "위치")
+//                    
+//                case .authIncompleted:
+//                    authNoticeBuilder(noticeItem: "마이크 및 음성인식")
+//                    authNoticeBuilder(noticeItem: "위치")
+//                    
+//                default:
+//                    Color.clear
+//                        .frame(height: 0)
+//                }
+//            }
+//            .padding(.top, 10)
+//            .padding(
+//                .bottom,
+//                authManager.authStatus == .authCompleted ? 0 : 24
+//            )
             
-            ForEach(sectionCategories, id: \.self) { category in
+            ForEach(
+                sectionCategories,
+                id: \.self
+            ) { category in
                 VStack(alignment: .leading) {
                     Text(category)
                         .foregroundColor(.GR8)
                         .font(.system(size: 20, weight: .bold))
                     
                     // Each Setting Cell
-                    ForEach(SectionType.allCases, id: \.rawValue) { item in
+                    ForEach(
+                        SectionType.allCases,
+                        id: \.rawValue
+                    ) { item in
                         if category == item.category {
                             NavigationLink {
                                 switch item {
                                 case .textReplacement:
                                     TKTextReplacementListView()
                                
-//                                case .guidingMessage:
-//                                    SettingsGuidingView()
+                                case .guidingMessage:
+                                    SettingsGuidingView()
                                 
+                                case .displayMode:
+                                    SettingsDisplayView()
+                                    // SettingsDisplayTestingView()
+                                   
                                     /*
-                                     case .displayMode:
-                                         SettingsDisplayView(
-                                             settingViewStore: settingViewStore
-                                         )
-                                    
                                      case .haptics:
-                                         SettingsHapticView(
-                                             settingViewStore: settingViewStore
-                                         )
-                                     
-                                     case .gesture:
-                                         SettingsGestureView(
-                                             settingViewStore: settingViewStore
-                                         )
+                                         SettingsHapticView()
                                      */
+                                    
+                                case .gesture:
+                                    SettingsGestureView()
                                     
                                 case .dataPolicyInfo:
                                     LoadingWebView()
@@ -154,42 +154,55 @@ struct SettingsListView: View {
             }
         }
         .scrollIndicators(.hidden)
-        .task {
-            await authStatus = SpeechAuthManager.switchAuthStatus()
-        }
+//        .onAppear {
+//            authManager.switchAuthStatus()
+//        }
     }
 }
 
 @ViewBuilder
 func authNoticeBuilder(noticeItem: String) -> some View {
-    HStack {
-        if noticeItem == "마이크와 음성인식" {
-            Image(systemName: "mic.slash.circle.fill")
-                .font(.system(size: 40))
-        } else if noticeItem == "위치" {
-            Image(systemName: "location.slash.circle.fill")
-                .font(.system(size: 40))
+    Button {
+        if let url = URL(
+            string: UIApplication.openSettingsURLString
+        ) {
+            UIApplication.shared.open(url)
         }
-        
-        VStack(alignment: .leading, spacing: 10) {
-            Text("\(noticeItem) 권한이 꺼져있어요.")
-                .font(.system(size: 17, weight: .bold))
-            
-            HStack {
-                Text("권한 허용하러 가기")
-                    .font(.system(size: 17, weight: .medium))
-                
-                Image(systemName: "arrow.up.forward.app.fill")
+    } label: {
+        HStack {
+            if noticeItem == "마이크 및 음성인식" {
+                Image(systemName: "mic.slash.circle.fill")
+                    .foregroundColor(.white) // white 고정값 맞아요!
+                    .font(.system(size: 45))
+            } else if noticeItem == "위치" {
+                Image(systemName: "location.slash.circle.fill")
+                    .foregroundColor(.white) // white 고정값 맞아요!
+                    .font(.system(size: 45))
             }
+            
+            VStack(alignment: .leading, spacing: 8) {
+                Text("\(noticeItem) 권한이 꺼져있어요.")
+                    .foregroundColor(.white) // white 고정값 맞아요!
+                    .font(.system(size: 17, weight: .bold))
+                
+                HStack {
+                    Text("권한 허용하러 가기")
+                        .foregroundColor(.white) // white 고정값 맞아요!
+                        .font(.system(size: 17, weight: .bold))
+                    
+                    Image(systemName: "arrow.up.forward.app.fill")
+                        .foregroundColor(.white) // white 고정값 맞아요!
+                }
+            }
+            
+            Spacer()
         }
-        
-        Spacer()
+        .foregroundColor(Color.BaseBGWhite)
+        .frame(maxWidth: .infinity)
+        .padding(16)
+        .background(Color.OR5)
+        .cornerRadius(22)
     }
-    .foregroundColor(Color.BaseBGWhite)
-    .frame(maxWidth: .infinity)
-    .padding(20)
-    .background(Color.OR5)
-    .cornerRadius(22)
 }
 
 #Preview {

--- a/talklat/talklat/talklatApp.swift
+++ b/talklat/talklat/talklatApp.swift
@@ -13,13 +13,16 @@ struct talklatApp: App {
     @Environment(\.scenePhase) private var scenePhase
     @StateObject private var store: TKMainViewStore = TKMainViewStore()
     @StateObject private var locationStore: TKLocationStore = TKLocationStore()
+    @StateObject private var authManager: TKAuthManager = TKAuthManager()
+    @StateObject private var colorSchemeManager = ColorSchemeManager()
+    
+//    @AppStorage("BDColorScheme") var colorScheme: ColorScheme = .unspecified
+    
     private var container: ModelContainer
     
     init() {
         do {
-            container = try ModelContainer(
-                for: TKConversation.self, TKTextReplacement.self
-            )
+            container = try ModelContainer(for: TKTextReplacement.self)
         } catch {
             fatalError("Failed to configure SwiftData container.")
         }
@@ -48,8 +51,19 @@ struct talklatApp: App {
                 }
             }
             .environmentObject(locationStore)
-            .onChange(of: scenePhase) { _, _ in
-                Color.colorScheme = UITraitCollection.current.userInterfaceStyle
+            .environmentObject(authManager)
+            .onChange(of: colorSchemeManager.colorScheme) { _, _ in
+                print("colorScheme Changed~~~~~~~~~~!!!!!!!!!!!!!!!!!")
+                Color.BDColorScheme = colorSchemeManager.colorScheme
+                print("color BDColorScheme: ", Color.BDColorScheme)
+            }
+            .environmentObject(colorSchemeManager)
+            .onAppear {
+                UserDefaults.standard.setValue(
+                    false,
+                    forKey: "_UIConstraintBasedLayoutLogUnsatisfiable"
+                )
+                colorSchemeManager.applyColorScheme()
             }
         }
         .modelContainer(container)

--- a/talklat/talklat/talklatApp.swift
+++ b/talklat/talklat/talklatApp.swift
@@ -16,8 +16,6 @@ struct talklatApp: App {
     @StateObject private var authManager: TKAuthManager = TKAuthManager()
     @StateObject private var colorSchemeManager = ColorSchemeManager()
     
-//    @AppStorage("BDColorScheme") var colorScheme: ColorScheme = .unspecified
-    
     private var container: ModelContainer
     
     init() {
@@ -52,11 +50,6 @@ struct talklatApp: App {
             }
             .environmentObject(locationStore)
             .environmentObject(authManager)
-            .onChange(of: colorSchemeManager.colorScheme) { _, _ in
-                print("colorScheme Changed~~~~~~~~~~!!!!!!!!!!!!!!!!!")
-                Color.BDColorScheme = colorSchemeManager.colorScheme
-                print("color BDColorScheme: ", Color.BDColorScheme)
-            }
             .environmentObject(colorSchemeManager)
             .onAppear {
                 UserDefaults.standard.setValue(


### PR DESCRIPTION
## 개요 및 관련 이슈

| ⚒️ Title | `Settings 접근성 (화면 모드) 수정 작업` | 
| :--- | :--- |
| 📜 **Description** | description |
| 📌 **Issue Number** | #169  |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/a42c6a40-0f1d-4372-9c9c-967d44803665" width='20'> **Figma** | [Link](<!-- URL -->) |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/c7f9920d-e975-4ed7-ad83-7e6e08611463" width='20'> **Notion** | [Link](<!-- URL -->) |

---

## 작업 사항
### 1. ColorSchemeManager 구현
- 변경되는 화면 모드를 UserDefaults에 저장하는 `colorScheme` 변수를 가지고 있습니다.
- 뷰에서 화면 모드 전환이 트리거 되고 UserDefaults의 모드 설정 값이 저장되자마자 `applyColorScheme` 메서드가 호출되어 화면모드가 설정된 모드로 전환됩니다.

### 2. Color Asset 추가
- 기존에 사용된 `TKColor`에서는 Color Extension에 각 색상을 getter 변수로 정의해주고 있었습니다. 이것에 관련해 렌더링이 즉각적으로 업데이트 되지 않는다는 문제점이 있었는데, 추측하기로는 색상 변수들이 switching하고 있는 타입은 `UserInterfaceStyle`인데, 이는 시스템의 화면 모드이지 앱 내에서 화면 모드를 조작시 사용되는 `ColorScheme` 타입과는 달라서 바로 전환이 안되는 것 같았습니다. 
- 이를 해결하기 위해 getter 값이 아닌 Asset 파일을 추가했습니다. (파일명을 Color Extension에 추가해두어 기존 컬러 사용법과는 동일합니다.) 

---
### `Logics`
#### ColorSchemeManager
```swift
enum ColorScheme: Int {
    case unspecified, light, dark
}

class ColorSchemeManager: ObservableObject {
    @AppStorage("BDColorScheme") var colorScheme: ColorScheme = .unspecified {
        didSet {
            applyColorScheme()
        }
    }
    
    func applyColorScheme() {
        keyWindow?.overrideUserInterfaceStyle = UIUserInterfaceStyle(
            rawValue: colorScheme.rawValue
        )!
    }
    
    var keyWindow: UIWindow? {
        guard let scene = UIApplication.shared.connectedScenes.first,
              let windowSceneDelegate = scene.delegate as? UIWindowSceneDelegate,
              let window = windowSceneDelegate.window else {
                  return nil
              }
        
        return window
    }
}
```
- 앱 Group이 onAppear하는 시점에서도 시스템의 화면 모드를 덮어씌우는 `applyColorScheme`이 호출됩니다. 
```swift
.onAppear {
    UserDefaults.standard.setValue(
        false,
        forKey: "_UIConstraintBasedLayoutLogUnsatisfiable"
    )
    colorSchemeManager.applyColorScheme()
}
```
---

## 작업 결과
| 완성본 | Color Asset을 사용하지 않을 때의 이슈 (셀 색상 변경 안됨) | 
| ---------- | ---------- |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/89244357/e2d044f3-9df2-4452-aea0-0f0abead96a6" width="250"> | <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/89244357/804d2d66-d795-4d35-918c-5fdd75434fc0" width="250"> |

---

#### 기타 공유사항
- 추후의 투두: 모든 "TK" 명칭은 "BD"로 변경해야 합니다.
