### PR TITLE
Feat/#187 custom history view add connection

### DIFF
--- a/talklat/bisdam.xcodeproj/project.pbxproj
+++ b/talklat/bisdam.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		5713DC502B0C9B9200ECF34B /* View+SwipeGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5713DC4F2B0C9B9200ECF34B /* View+SwipeGesture.swift */; };
 		5713DC4C2B0B3BC600ECF34B /* BDText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5713DC4B2B0B3BC600ECF34B /* BDText.swift */; };
+		5713DC502B0C9B9200ECF34B /* View+SwipeGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5713DC4F2B0C9B9200ECF34B /* View+SwipeGesture.swift */; };
 		577B45202B0DE76500DA010E /* Pretendard-Thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = 577B45172B0DE76500DA010E /* Pretendard-Thin.otf */; };
 		577B45212B0DE76500DA010E /* Pretendard-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = 577B45182B0DE76500DA010E /* Pretendard-Black.otf */; };
 		577B45222B0DE76500DA010E /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 577B45192B0DE76500DA010E /* Pretendard-SemiBold.otf */; };
@@ -123,6 +123,7 @@
 		7ED9AA082ACE8E4300B1EA4E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E8D17CB2ACE8AED00E904E5 /* Preview Assets.xcassets */; };
 		7ED9AA092ACE8E4300B1EA4E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E8D17C82ACE8AED00E904E5 /* Assets.xcassets */; };
 		CE405C2D2B0CD7E4003F2586 /* OptionalInt+Distance.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE405C2C2B0CD7E4003F2586 /* OptionalInt+Distance.swift */; };
+		CE405C312B0F3C2F003F2586 /* TKDraggableListViewStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE405C302B0F3C2F003F2586 /* TKDraggableListViewStore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -143,8 +144,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		5713DC4F2B0C9B9200ECF34B /* View+SwipeGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+SwipeGesture.swift"; sourceTree = "<group>"; };
 		5713DC4B2B0B3BC600ECF34B /* BDText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BDText.swift; sourceTree = "<group>"; };
+		5713DC4F2B0C9B9200ECF34B /* View+SwipeGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+SwipeGesture.swift"; sourceTree = "<group>"; };
 		572304FE2B00AF350098FFF5 /* TextReplacementViewStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextReplacementViewStore.swift; sourceTree = "<group>"; };
 		572A82032B03300B00753516 /* Character+Consonant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Character+Consonant.swift"; sourceTree = "<group>"; };
 		574D418B2B05E662007EFE90 /* SettingsTeamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTeamView.swift; sourceTree = "<group>"; };
@@ -227,6 +228,7 @@
 		CE2744002AFBE08B006C2645 /* HistoryInfoItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryInfoItemView.swift; sourceTree = "<group>"; };
 		CE2744022AFBE0D3006C2645 /* HistoryItemLocationEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryItemLocationEditView.swift; sourceTree = "<group>"; };
 		CE405C2C2B0CD7E4003F2586 /* OptionalInt+Distance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OptionalInt+Distance.swift"; sourceTree = "<group>"; };
+		CE405C302B0F3C2F003F2586 /* TKDraggableListViewStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKDraggableListViewStore.swift; sourceTree = "<group>"; };
 		CE79CAEA2AF0CEC20007713B /* TKLocationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TKLocationStore.swift; sourceTree = "<group>"; };
 		CEF43C472ADA97FF00DE02A9 /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
 		EF1162AA2AFCB90F000D0F5B /* HistoryListSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryListSearchView.swift; sourceTree = "<group>"; };
@@ -511,6 +513,7 @@
 				572304FE2B00AF350098FFF5 /* TextReplacementViewStore.swift */,
 				CE79CAEA2AF0CEC20007713B /* TKLocationStore.swift */,
 				CE0CBF4F2B04D8BA0048C784 /* TKHistoryInfoStore.swift */,
+				CE405C302B0F3C2F003F2586 /* TKDraggableListViewStore.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -822,6 +825,7 @@
 				7EBD313E2B0B2B1300D5514D /* TKTextReplacementListView.swift in Sources */,
 				7EBD313F2B0B2B1300D5514D /* SectionIndexTitles.swift in Sources */,
 				7EBD31402B0B2B1300D5514D /* SettingTRTextField.swift in Sources */,
+				CE405C312B0F3C2F003F2586 /* TKDraggableListViewStore.swift in Sources */,
 				7EBD31412B0B2B1300D5514D /* SettingTRSearchBar.swift in Sources */,
 				7EBD31422B0B2B1300D5514D /* TextReplacementRow.swift in Sources */,
 				7EBD31432B0B2B1300D5514D /* TKTextReplacementEditView.swift in Sources */,
@@ -1024,7 +1028,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2311222320;
 				DEVELOPMENT_ASSET_PATHS = "\"talklat/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = MTUYFM4K8P;
 				DEVELOPMENT_TEAM = CZH2CMCGCZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1067,7 +1070,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2311222320;
 				DEVELOPMENT_ASSET_PATHS = "\"talklat/Resources/Preview Content\"";
-				DEVELOPMENT_TEAM = MTUYFM4K8P;
 				DEVELOPMENT_TEAM = CZH2CMCGCZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/talklat/talklat/Sources/Stores/TKConversationViewStore.swift
+++ b/talklat/talklat/Sources/Stores/TKConversationViewStore.swift
@@ -51,6 +51,7 @@ final class TKConversationViewStore {
         var bottomInset: CGFloat = 0
         var isTopViewShown: Bool = false
         var isHistoryViewShownWithTransition: Bool = false
+        var previousConversation: TKConversation? = nil
     }
     
     @Published private var viewState: ConversationState = ConversationState(conversationStatus: .writing)
@@ -150,6 +151,19 @@ extension TKConversationViewStore {
     }
     
     public func onSaveNewConversationButtonTapped() {
+        withAnimation {
+            reduce(
+                \.isNewConversationSaved,
+                 into: true
+            )
+        }
+    }
+    
+    public func onSaveToPreviousButtonTapped(_ newContents: [TKContent]) {
+        if let _ = self(\.previousConversation) {
+            self(\.previousConversation)?.content.append(contentsOf: newContents)
+        }
+        
         withAnimation {
             reduce(
                 \.isNewConversationSaved,

--- a/talklat/talklat/Sources/Stores/TKDraggableListViewStore.swift
+++ b/talklat/talklat/Sources/Stores/TKDraggableListViewStore.swift
@@ -1,0 +1,44 @@
+//
+//  TKRecentConversationListViewStore.swift
+//  bisdam
+//
+//  Created by user on 11/23/23.
+//
+
+import Foundation
+import SwiftUI
+
+class TKDraggableListViewStore: TKReducer {
+    struct ViewState {
+        var isShowingConversationView: Bool = false
+        var conversations: [TKConversation] = [TKConversation]()
+//        var selectedConversation: TKConversation = TKConversation(
+//            title: "",
+//            createdAt: Date(),
+//            content: [TKContent]()
+//        )
+    }
+    
+    @Published private var viewState: ViewState = ViewState()
+    
+    func callAsFunction<Value>(_ path: KeyPath<ViewState, Value>) -> Value where Value : Equatable {
+        return self.viewState[keyPath: path]
+    }
+    
+    func reduce<Value>(_ path: WritableKeyPath<ViewState, Value>, into newValue: Value) where Value : Equatable {
+        self.viewState[keyPath: path] = newValue
+    }
+    
+    
+    public func bindingIsShowingConversationView() -> Binding<Bool> {
+        return Binding(
+            get: { self(\.isShowingConversationView) },
+            set: { self.reduce(\.isShowingConversationView, into: $0) }
+        )
+    }
+    
+    public func onTapDraggableListItem(_ conversation: TKConversation) {
+//        self.reduce(\.selectedConversation, into: conversation)
+        self.reduce(\.isShowingConversationView, into: true)
+    }
+}

--- a/talklat/talklat/Sources/Stores/TKDraggableListViewStore.swift
+++ b/talklat/talklat/Sources/Stores/TKDraggableListViewStore.swift
@@ -12,11 +12,6 @@ class TKDraggableListViewStore: TKReducer {
     struct ViewState {
         var isShowingConversationView: Bool = false
         var conversations: [TKConversation] = [TKConversation]()
-//        var selectedConversation: TKConversation = TKConversation(
-//            title: "",
-//            createdAt: Date(),
-//            content: [TKContent]()
-//        )
     }
     
     @Published private var viewState: ViewState = ViewState()
@@ -38,7 +33,6 @@ class TKDraggableListViewStore: TKReducer {
     }
     
     public func onTapDraggableListItem(_ conversation: TKConversation) {
-//        self.reduce(\.selectedConversation, into: conversation)
         self.reduce(\.isShowingConversationView, into: true)
     }
 }

--- a/talklat/talklat/Sources/Views/Main/TKDraggableList.swift
+++ b/talklat/talklat/Sources/Views/Main/TKDraggableList.swift
@@ -12,7 +12,6 @@ struct TKDraggableList: View {
     @ObservedObject var mainViewstore: TKMainViewStore
     @ObservedObject var conversationViewStore: TKConversationViewStore
     @StateObject private var draggableListViewStore: TKDraggableListViewStore = TKDraggableListViewStore()
-    @State private var conversations: [TKConversation] = [TKConversation]()
     @GestureState var gestureOffset: CGFloat = 0
     let firstOffset = UIScreen.main.bounds.height * 0.65
     let dataStore: TKSwiftDataStore = TKSwiftDataStore()
@@ -51,7 +50,10 @@ struct TKDraggableList: View {
             .onChange(of: locationStore(\.authorizationStatus)) { _, _ in
                 if locationStore.detectAuthorization() {
                     locationStore.trackUserCoordinate()
-                    conversations = locationStore.getClosestConversation(dataStore.conversations)
+                    draggableListViewStore.reduce(
+                        \.conversations,
+                         into: locationStore.getClosestConversation(dataStore.conversations)
+                    )
                 }
             }
             .onChange(of: locationStore(\.currentUserCoordinate)) { _, _ in

--- a/talklat/talklat/Sources/Views/Main/TKMainView.swift
+++ b/talklat/talklat/Sources/Views/Main/TKMainView.swift
@@ -76,7 +76,7 @@ struct TKMainView: View {
             
 
 //            // MARK: BottomSheet
-            TKDraggableList(store: store)
+            TKDraggableList(mainViewstore: store, conversationViewStore: conversationViewStore)
         }
         .fullScreenCover(isPresented: store.bindingConversationFullScreenCover()) {
             TKConversationView(store: conversationViewStore)

--- a/talklat/talklat/Sources/Views/Main/TKRecentConversationListView.swift
+++ b/talklat/talklat/Sources/Views/Main/TKRecentConversationListView.swift
@@ -107,7 +107,6 @@ struct TKRecentConversationListView: View {
                         \.conversations,
                          into: locationStore.getClosestConversation(swiftDataStore.conversations)
                     )
-//                    conversations = locationStore.getClosestConversation(swiftDataStore.conversations)
                 }
             }
         }
@@ -115,18 +114,6 @@ struct TKRecentConversationListView: View {
             TKConversationView(store: conversationViewStore)
                 .onDisappear {
                     conversationViewStore.resetConversationState()
-                }
-                .onChange(of: conversationViewStore(\.isConversationFullScreenDismissed)) { old, new in
-                    if !old, new {
-//                        store.onConversationFullscreenDismissed()
-//                        dismiss()
-                    }
-                }
-                .onChange(of: conversationViewStore(\.isNewConversationSaved)) { _, isSaved in
-                    if isSaved {
-//                        self.recentConversation = swiftDataStore.getRecentConversation()
-//                        store.onNewConversationHasSaved()
-                    }
                 }
         }
     }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->

<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `Draggable List connected` | 
| :--- | :--- |
| 📜 **Description** | DraggableList를 눌러서 대화를 다시 이어서 시작할 수 있게 되었습니다. |
| 📌 **Issue Number** | #187  |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/a42c6a40-0f1d-4372-9c9c-967d44803665" width='20'> **Figma** | [Link](<!-- URL -->) |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/c7f9920d-e975-4ed7-ad83-7e6e08611463" width='20'> **Notion** | [Link](<!-- URL -->) |

---

## 작업 사항
<!-- 1. MainIntroView의 ScrollView 구현 -->
1. 작업 내용
  - TKDraggableList의 아이템을 누르면 이제 해당 TKConversation에 현재 진행되는 대화가 추가가 됩니다.

### `Logics`
1.  TKDraggableListViewStore가 새로 생성되었습니다. TKDraggableListViewStore가 하는 일은 fullScreen으로 DraggableList를 보여주기, 그리고 가까운 거리의 대화목록을 담고 있습니다.
<br></br>
2. TKRecentConversationListView에서 NavigaitonLink로 CustomHistoryView로 넘어가던 로직이 기능변경 요청으로 인해 CustomHistoryView로 넘어가지 않고 바로 ConversationView를 FullScreenCover로 띄우게 됩니다. 그러기 위해서 TKDraggableList와 TKRecentConversationListView는 하나의 TKDraggableListViewStore를 공유합니다.
<br></br>
3. 기존의 TKTypingView에서는 반드시 새로운 대화가 생성되어야했던것과는 달리, 이제는 새로운 대화가 생성될 수도, 아니면 이어서 할 수도 있기 때문에 TKTypingView의 변화가 일어났으며, TKConversationViewStore에서 이제 previousConversation이라는 변수에 이전 대화가 있다면 해당 대화를, 없다면 nil을 담고 있습니다.


---

## 작업 결과
|이어대화하기|
|--|
|![draggable](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/22471820/ab89fd99-f315-4a5a-b4b3-693fed5e531b)|

---

#### 기타 공유사항
- 여러군데를 손 봐야했기 때문에 혹시 뭔가 틀어진것 같다고 생각되시면 언제든지 연락 주세요 :)
