### PR TITLE
Refactor/#212 TKReducer refactoring

### DIFF
--- a/talklat/talklat/Sources/Stores/TKDraggableListViewStore.swift
+++ b/talklat/talklat/Sources/Stores/TKDraggableListViewStore.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 class TKDraggableListViewStore: TKReducer {
-    struct ViewState {
+    struct ViewState: Equatable {
         var isShowingConversationView: Bool = false
         var conversations: [TKConversation] = [TKConversation]()
     }

--- a/talklat/talklat/Sources/Stores/TKHistoryInfoStore.swift
+++ b/talklat/talklat/Sources/Stores/TKHistoryInfoStore.swift
@@ -10,7 +10,7 @@ import MapKit
 import SwiftUI
 
 class TKHistoryInfoStore: TKReducer {
-    struct ViewState {
+    struct ViewState: Equatable {
         var isShowingSheet: Bool = false
         var isShowingAlert: Bool = false
         var text: String = ""

--- a/talklat/talklat/Sources/Stores/TKLocationStore.swift
+++ b/talklat/talklat/Sources/Stores/TKLocationStore.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 class TKLocationStore: NSObject, CLLocationManagerDelegate, TKReducer {
     // Equatable에 conform 시키기 위해 extension을 쓰는것보다는 최대한 원시타입을 씁시다 - 갓짤랑
-    struct ViewState {
+    struct ViewState: Equatable {
         var currentUserCoordinate: MKCoordinateRegion? = nil
         var currentUserPlaceName: String? = nil
         


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->

<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `TKReducer refactoring` | 
| :--- | :--- |
| 📜 **Description** | TKReducer Parent-Child Communication 구현 |
| 📌 **Issue Number** | #212 |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/a42c6a40-0f1d-4372-9c9c-967d44803665" width='20'> **Figma** | _ |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/c7f9920d-e975-4ed7-ad83-7e6e08611463" width='20'> **Notion** | _ |

---

## 작업 사항
<!-- 1. MainIntroView의 ScrollView 구현 -->
1. TKReducer의 부모-자식 간 소통을 View가 아닌 Store에서 진행할 수 있도록 프로토콜을 개선했습니다.
  - 현재 모든 TKReducer의 Instance가 listen을 구현해야 하지만 extension으로 갈음되어 있습니다.
  - 추후 서브 브랜치에서 수정할 예정입니다.
  - 사용 예시는 아래 코드에서 확인할 수 있습니다.

### `TKReducer`
- 부모와 자식은 listen과 notify로 소통합니다.
  - 자식이 notify 하며, 이 메소드는 기본 구현 형태를 사용합니다.
  - 부모가 listen 하며, 이 메소드는 각 Store에서 각각 구현해야 합니다.
- Child Store는 parent의 인스턴스를 약하게 참조합니다.
  - `weak var parent: (any TKReducer)?` 형태로 선언하고 View의 onAppear 시점에 할당합니다.

```swift
// Protocol
extension TKReducer {
  // 임시로 구현해 둔 기본 구현
  func listen<Child: TKReducer, Value: Equatable>
  (to: Child, _ path: KeyPath<Child.ViewState, Value>, value: Value) { }

  /// notify 메소드는 Child에서 호출한다.
  /// - Parameters:
  ///   - parent: 변경된 사항을 받기 위한 Parent
  ///   - path: 변경된 path를 전달
  ///   - value: 변경된 값을 전달
  func notify<Parent: TKReducer, Value: Equatable>
  (to parent: Parent, path: KeyPath<ViewState, Value>, value: Value) {
    parent.listen(to: self, path, value: value)
  }
}

// Parent Store
extension ParentReducer: TKReducer {
  func listen<Child: TKReducer, Value: Equatable>
  (to: Child, _ path: KeyPath<Child.ViewState, Value>, value: Value) {
    // 어떤 Child Store의 Path를 case 처리할 것인지 정의합니다.
    // 모든 Child Store의 ViewState에 대한 path를 처리할 수 있습니다.
    typealias ChildState = ChildReducer.ViewState
    
    switch path {
    case \ChildState.childName:
      reduce(\.parentName, into: value as! String)
    case \ChildState.booleann:
      reduce(\.booo, into: value as! Bool)
    case \ChildReducer2.ViewState.myName:
      reduce(\.parentName, into: value as! String)
    default:
      break
    }
  }
}

// Child Store
final class ChildReducer: TKReducer {
  weak var parent: (any TKReducer)?
  
  struct ViewState: Equatable {
    var childName: String = "Child"
  }
  
  @Published private var viewState: ViewState = ViewState()
  
  func onUpdateName(with str: String) {
    reduce(\.childName, into: str)
    guard let parent else { return }
    // Parent 에게 어떤 경로에서 어떤 값으로 변했는지 notify 합니다.
    // reduce가 아닌 각 Action에서 호출하여,
    // Child에 먼저 변화를 줄지, Parent에 먼저 변화를 줄지 결정합니다.
    notify(to: parent, path: \.childName, value: str)
  }
}
```

---

## 작업 결과
<!-- 이미지, gif 등을 캡쳐하여 첨부합니다. -->
<!-- 해당 섹션은 필수가 아닙니다! -->

---

#### 기타 공유사항
<!-- 야기될 수 있는 사이드 이펙트, 조사가 필요한 내용 등을 작성합니다. --> 
1. 현재 버전은 TKReducer의 기본 구현에 의존적인 listen 메소드가 있어서 추후 유지보수와 테스트를 방해할 수 있습니다.
2. 서브 브랜치에서 작업 예정입니다.
3. 사용법이 헷갈리신다면 언제든 질문..!!!!!