### PR TITLE
[Fix/#211] darkmode Background가 잘못된 frame을 갖던 이슈를 해결합니다.

### DIFF
--- a/talklat/talklat/Sources/Views/Settings/TextReplacement/TKTextReplacementAddView.swift
+++ b/talklat/talklat/Sources/Views/Settings/TextReplacement/TKTextReplacementAddView.swift
@@ -97,8 +97,8 @@ struct TKTextReplacementAddView: View {
                 .padding(.bottom, 24)
             }
         }
-        .background(Color.SheetBGWhite)
         .padding(.horizontal, 16)
+        .background(Color.SheetBGWhite)
     }
 }
 


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->

<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `TextReplacementAddView의 darkmode Background의 잘못된 frame 수정` | 
| :--- | :--- |
| 📜 **Description** | darkmode Background가 잘못된 frame을 갖던 이슈를 해결합니다. |
| 📌 **Issue Number** | #211 |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/a42c6a40-0f1d-4372-9c9c-967d44803665" width='20'> **Figma** | _ |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/c7f9920d-e975-4ed7-ad83-7e6e08611463" width='20'> **Notion** | _ |

---

## 작업 사항
<!-- 1. MainIntroView의 ScrollView 구현 -->
1. padding이 background 밖에서 제한되었던 현상을 간단히 수정하여 background가 정상적으로 반영되도록 개선완료

---

## 작업 결과
<!-- 이미지, gif 등을 캡쳐하여 첨부합니다. -->
<!-- 해당 섹션은 필수가 아닙니다! -->
| 수정 전 | 수정 후 |
| :--: | :---: |
| ![simulator_screenshot_0702DF5B-D983-49B1-B202-DA8287009F04](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/c85e5b39-d31c-4d21-9174-a1e6dc73bd08) | ![simulator_screenshot_AEF1707E-30AF-4D09-A097-1809CC3FB95A](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/223763ec-31e5-4f08-86d4-3ba7f8218951) |
---

#### 기타 공유사항
- nil!