### PR TITLE
Fix/#233 conversation stt flow fix

### DIFF
--- a/talklat/talklat/Sources/Utilities/Constants.swift
+++ b/talklat/talklat/Sources/Utilities/Constants.swift
@@ -86,6 +86,13 @@ public enum Constants {
         앱 설정에서 모든 권한을 허용해 주세요.
         """
     }
+  
+    enum Conversation {
+      static let NO_RESPONSE: String =
+      """
+      (기록된 답변이 없어요.)
+      """
+    }
     
     static let START_CONVERSATION_MESSAGE: String =
     """

--- a/talklat/talklat/Sources/Views/Components/TKScrollView.swift
+++ b/talklat/talklat/Sources/Views/Components/TKScrollView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct TKScrollView: View {
     enum TKScrollContents {
-        case question(question: String, answer: String, curtainAlignment: Alignment)
+        case question(question: String, answer: String)
         case answer(answer: String, curtainAlignment: Alignment)
         case answerCard(text: String, curtainAlignment: Alignment)
     }
@@ -27,7 +27,7 @@ struct TKScrollView: View {
     // MARK: - BODY
     var body: some View {
         switch style {
-        case let .question(question, answer, align):
+        case let .question(question, answer):
             VStack {
                 if question.isEmpty && answer.isEmpty {
                     BDText(text: Constants.SHOWINGVIEW_GUIDINGMESSAGE, style: .T1_B_170)

--- a/talklat/talklat/Sources/Views/Conversation/TKConversationView.swift
+++ b/talklat/talklat/Sources/Views/Conversation/TKConversationView.swift
@@ -24,7 +24,6 @@ struct TKConversationView: View {
                     store: store,
                     namespaceID: TKTransitionNamespace
                 )
-//                .transition(.opacity)
             }
             
             if store(\.conversationStatus) == .guiding {

--- a/talklat/talklat/Sources/Views/Conversation/TKListeningView.swift
+++ b/talklat/talklat/Sources/Views/Conversation/TKListeningView.swift
@@ -53,8 +53,7 @@ struct TKListeningView: View {
                 TKScrollView(
                     style: .question(
                         question: store(\.questionText),
-                        answer: store(\.answeredText),
-                        curtainAlignment: .bottom
+                        answer: store(\.answeredText)
                     ), curtain: {
                         LinearGradient(
                             colors: [.BaseBGWhite, .clear],
@@ -185,6 +184,7 @@ struct TKListeningView: View {
                         }
                 }
             }
+            .disabled(store(\.answeredText.isEmpty))
             .disabled(store(\.blockButtonDoubleTap))
         }
     }


### PR DESCRIPTION
## 개요 및 관련 이슈

| ⚒️ Title | `Conversation > STT가 없을 때의 플로우 이탈 에러 수정` | 
| :--- | :--- |
| 📜 **Description** | Conversation > STT가 없을 때의 플로우 이탈 에러 수정 |
| 📌 **Issue Number** | #233 |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/a42c6a40-0f1d-4372-9c9c-967d44803665" width='20'> **Figma** | [Link](https://www.figma.com/file/Mb450yYTvio6Q9y6d0otwv/%F0%9F%8D%8EBISDAM-Project?type=design&node-id=7295-43243&mode=dev) |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/c7f9920d-e975-4ed7-ad83-7e6e08611463" width='20'> **Notion** | _ |

---

## 작업 사항
<!-- 1. MainIntroView의 ScrollView 구현 -->
1. STT Conversation 플로우에서 상대방의 응답이 없을 때, 하단의 버튼이 disabled 되고, chevron이 보여지지 않도록 수정

---

## 작업 결과
<!-- 이미지, gif 등을 캡쳐하여 첨부합니다. -->
<!-- 해당 섹션은 필수가 아닙니다! -->

| GIF |
| :---: |
|![Simulator Screen Recording - iPhone 15 Pro Max - 2024-04-05 at 17 50 49](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/ed8272f6-ec27-4ad4-9496-dd66f5c5e7ca) |

