### PR TITLE
[Fix/#250] Draggable List의 padding 값 조절

### DIFF
--- a/talklat/talklat/Sources/Views/Main/TKDraggableList.swift
+++ b/talklat/talklat/Sources/Views/Main/TKDraggableList.swift
@@ -38,7 +38,7 @@ struct TKDraggableList: View {
                     conversationViewStore: conversationViewStore,
                     draggableListViewStore: draggableListViewStore
                 )
-                .padding(.top, 32)
+                .padding(.top, 12)
                 .scrollDisabled(!mainViewstore(\.isBottomSheetMaxed))
                 .scrollIndicators(.hidden)
             }
@@ -101,6 +101,11 @@ struct TKDraggableList: View {
 #Preview {
     ZStack {
         Color.yellow
-        TKDraggableList(mainViewstore: .init(), conversationViewStore: .init())
+      
+        TKDraggableList(
+            mainViewstore: .init(),
+            conversationViewStore: .init()
+        )
+        .environmentObject(TKLocationStore())
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- MainIntroView의 UI 구현 (예시) -->
<!-- Issue Link: #1 -->
<!-- Figma: Link (선택) -->

<!-- Notion Card: Link (선택) -->

| ⚒️ Title | `Draggable List의 padding 값 조절` | 
| :--- | :--- |
| 📜 **Description** | Draggable List의 캡슐과 제목의 padding 값 조절 |
| 📌 **Issue Number** | #250 |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/a42c6a40-0f1d-4372-9c9c-967d44803665" width='20'> **Figma** | _ |
| <img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-ALLWAY/assets/82270058/c7f9920d-e975-4ed7-ad83-7e6e08611463" width='20'> **Notion** | _ |

---

## 작업 사항
<!-- 1. MainIntroView의 ScrollView 구현 -->
1. Draggable List의 padding 값 조정
